### PR TITLE
fix: install from GitHub repo instead of PyPI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 PACKAGE="celltype-cli"
+REPO_URL="git+https://github.com/celltype/cli.git"
 MIN_PYTHON="3.10"
 
 # ── Helpers ────────────────────────────────────────────────────
@@ -45,17 +46,19 @@ esac
 
 # ── Install package ────────────────────────────────────────────
 
-if command -v pipx >/dev/null 2>&1; then
-    info "Installing ${PACKAGE} via pipx..."
-    pipx install "$PACKAGE" || pipx upgrade "$PACKAGE"
-    ok "Installed with pipx"
-elif command -v uv >/dev/null 2>&1; then
+INSTALL_SPEC="${PACKAGE} @ ${REPO_URL}"
+
+if command -v uv >/dev/null 2>&1; then
     info "Installing ${PACKAGE} via uv..."
-    uv tool install "$PACKAGE" || uv tool upgrade "$PACKAGE"
+    uv tool install "$INSTALL_SPEC" || uv tool install --force "$INSTALL_SPEC"
     ok "Installed with uv"
+elif command -v pipx >/dev/null 2>&1; then
+    info "Installing ${PACKAGE} via pipx..."
+    pipx install "$REPO_URL" || pipx install --force "$REPO_URL"
+    ok "Installed with pipx"
 else
-    warn "pipx/uv not found — falling back to pip install --user"
-    "$PYTHON" -m pip install --user --upgrade "$PACKAGE"
+    warn "uv/pipx not found — falling back to pip install --user"
+    "$PYTHON" -m pip install --user --upgrade "$INSTALL_SPEC"
     ok "Installed with pip"
 
     # Check if user bin is on PATH


### PR DESCRIPTION
## Summary

- **Fix install script failing** because `celltype-cli` is not published on PyPI — `uv tool install celltype-cli` and `pipx install celltype-cli` both fail with "No solution found when resolving dependencies"
- Install directly from the GitHub repository using `git+https://github.com/celltype/cli.git` URLs
- Prefer `uv` over `pipx` (faster, more widely available)

## What changed

- Added `REPO_URL` variable pointing to `git+https://github.com/celltype/cli.git`
- Updated `uv tool install`, `pipx install`, and `pip install` commands to use the git URL
- Swapped preference order: `uv` → `pipx` → `pip` (was `pipx` → `uv` → `pip`)
- Use `--force` flag for re-installs/upgrades instead of separate upgrade commands

## Test plan

- [ ] Run `curl -fsSL https://raw.githubusercontent.com/naofel1/cli/fix/install-from-github/install.sh | bash` on macOS with uv installed
- [ ] Run on a machine with only pipx
- [ ] Run on a machine with only pip
- [ ] Verify `ct --version` works after install


Made with [Cursor](https://cursor.com)