### PR TITLE
Add BindCraft de novo protein binder design tool

### DIFF
--- a/src/ct/cloud/local_runner.py
+++ b/src/ct/cloud/local_runner.py
@@ -132,6 +132,8 @@ class LocalRunner:
             "PROTEINMPNN_CACHE": (home / ".cache" / "proteinmpnn", "/root/.cache/proteinmpnn"),
             # DiffDock score/confidence models
             "DIFFDOCK_CACHE": (home / ".cache" / "diffdock", "/root/.cache/diffdock"),
+            # BindCraft AF2 weights + design caches
+            "BINDCRAFT_CACHE": (home / ".cache" / "bindcraft", "/root/.cache/bindcraft"),
         }
 
         for env_var, (host_path, container_path) in cache_mappings.items():

--- a/src/ct/tools/bindcraft/Dockerfile
+++ b/src/ct/tools/bindcraft/Dockerfile
@@ -1,0 +1,52 @@
+# BindCraft — de novo protein binder design
+# Source: https://github.com/martinpacesa/BindCraft
+# License: MIT
+# Hardware: A100/H100 GPU, 32-80GB VRAM
+# Uses JAX + CUDA for AlphaFold2 backpropagation
+
+FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.11 python3.11-venv python3.11-dev python3-pip git wget \
+    build-essential libffi-dev libssl-dev \
+    && ln -sf /usr/bin/python3.11 /usr/bin/python3 \
+    && python3 -m pip install --upgrade pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/martinpacesa/BindCraft.git /app/BindCraft
+
+WORKDIR /app/BindCraft
+
+RUN pip install --no-cache-dir \
+    "jax[cuda12]" \
+    numpy \
+    pandas \
+    biopython \
+    scipy \
+    matplotlib \
+    dm-haiku \
+    dm-tree \
+    ml-collections \
+    immutabledict \
+    chex \
+    optax
+
+RUN if [ -f /app/BindCraft/requirements.txt ]; then \
+        pip install --no-cache-dir -r /app/BindCraft/requirements.txt; \
+    fi
+
+RUN pip install --no-cache-dir \
+    git+https://github.com/sokrypton/ColabDesign.git
+
+RUN git clone --depth 1 https://github.com/dauparas/ProteinMPNN.git /app/ProteinMPNN
+
+# AF2 weights are cached on host and mounted at runtime
+RUN mkdir -p /root/.cache/bindcraft /root/.cache/alphafold
+
+COPY tool_entrypoint.py /opt/tool_entrypoint.py
+COPY implementation.py /opt/implementation.py
+RUN mkdir -p /workspace
+WORKDIR /workspace
+ENTRYPOINT ["python3", "/opt/tool_entrypoint.py"]

--- a/src/ct/tools/bindcraft/implementation.py
+++ b/src/ct/tools/bindcraft/implementation.py
@@ -1,0 +1,413 @@
+"""BindCraft — de novo protein binder design pipeline.
+Hardware: A100/H100 GPU, 32-80GB VRAM.
+Uses AlphaFold2 backpropagation + ProteinMPNN + PyRosetta scoring.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+
+BINDCRAFT_DIR = "/app/BindCraft"
+PROTEINMPNN_DIR = "/app/ProteinMPNN"
+ALLOWED_PATH_SUFFIXES = {".pdb", ".cif", ".mmcif", ".ent"}
+ALLOWED_DESIGN_MODES = {"default", "betasheet", "peptide"}
+ALLOWED_ARGS = {
+    "target_pdb",
+    "pdb_text",
+    "chains",
+    "hotspot_residues",
+    "binder_length_min",
+    "binder_length_max",
+    "num_designs",
+    "design_mode",
+    "binder_name",
+    "session_id",
+}
+
+
+def _get_gpu_vram_mb():
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+            text=True,
+            timeout=5,
+        )
+        return int(out.strip().split("\n")[0])
+    except Exception:
+        return 0
+
+
+def _monitor_vram(stop_event, results):
+    peak = 0
+    while not stop_event.is_set():
+        vram = _get_gpu_vram_mb()
+        if vram > peak:
+            peak = vram
+        results["peak"] = peak
+        stop_event.wait(0.5)
+    vram = _get_gpu_vram_mb()
+    if vram > peak:
+        results["peak"] = vram
+
+
+def _require_inline_pdb_text(pdb_text: str) -> str:
+    pdb_text = str(pdb_text or "").strip()
+    if not pdb_text:
+        raise ValueError("BindCraft requires non-empty inline PDB text in `target_pdb`.")
+    lines = [line for line in pdb_text.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError("BindCraft requires non-empty inline PDB text in `target_pdb`.")
+    if not any(line.startswith(("ATOM", "HETATM")) for line in lines):
+        raise ValueError("BindCraft requires PDB text with ATOM/HETATM records.")
+    return pdb_text
+
+
+def _load_target_pdb_file(target_pdb: str) -> str:
+    path = str(target_pdb or "").strip()
+    if not path:
+        raise ValueError("BindCraft requires either `target_pdb` (inline PDB) or a file path.")
+    if not os.path.isfile(path):
+        raise ValueError("BindCraft `target_pdb` must point to an existing local structure file.")
+    if os.path.splitext(path)[1].lower() not in ALLOWED_PATH_SUFFIXES:
+        raise ValueError("BindCraft `target_pdb` must be a .pdb, .cif, .mmcif, or .ent file.")
+    with open(path, encoding="utf-8") as fh:
+        return _require_inline_pdb_text(fh.read())
+
+
+def _parse_chain_ids(pdb_text: str) -> set[str]:
+    chains = set()
+    for line in pdb_text.splitlines():
+        if line.startswith(("ATOM", "HETATM")) and len(line) > 21:
+            chain_id = line[21].strip()
+            if chain_id:
+                chains.add(chain_id)
+    return chains
+
+
+def _count_residues(pdb_text: str) -> int:
+    seen = set()
+    for line in pdb_text.splitlines():
+        if line.startswith("ATOM") and " CA " in line and len(line) > 26:
+            chain = line[21]
+            resnum = line[22:26].strip()
+            seen.add((chain, resnum))
+    return len(seen)
+
+
+def normalize_args(args: dict) -> dict:
+    unexpected = sorted(set(args) - ALLOWED_ARGS)
+    if unexpected:
+        raise ValueError(f"BindCraft received unsupported arguments: {', '.join(unexpected)}.")
+
+    normalized = dict(args)
+
+    target_pdb = str(normalized.get("target_pdb", "")).strip()
+    pdb_text = str(normalized.get("pdb_text", "")).strip()
+    if pdb_text:
+        inline_content = _require_inline_pdb_text(pdb_text)
+    elif target_pdb:
+        if "\n" in target_pdb or target_pdb.startswith(("ATOM", "HETATM", "HEADER", "MODEL")):
+            inline_content = _require_inline_pdb_text(target_pdb)
+        else:
+            inline_content = _load_target_pdb_file(target_pdb)
+    else:
+        raise ValueError("BindCraft requires `target_pdb` (PDB content or file path).")
+
+    normalized["target_pdb"] = inline_content
+
+    available_chains = _parse_chain_ids(inline_content)
+    chains = str(normalized.get("chains", "")).strip()
+    if not chains:
+        chains = sorted(available_chains)[0] if available_chains else "A"
+    for ch in chains.replace(",", ""):
+        if ch.strip() and ch.strip() not in available_chains:
+            raise ValueError(
+                f"Chain '{ch.strip()}' not found in target PDB. Available: {sorted(available_chains)}"
+            )
+    normalized["chains"] = chains
+
+    normalized["hotspot_residues"] = str(normalized.get("hotspot_residues", "")).strip()
+
+    try:
+        binder_min = int(normalized.get("binder_length_min", 65))
+    except (TypeError, ValueError):
+        binder_min = 65
+    try:
+        binder_max = int(normalized.get("binder_length_max", 150))
+    except (TypeError, ValueError):
+        binder_max = 150
+    binder_min = max(4, min(250, binder_min))
+    binder_max = max(binder_min, min(250, binder_max))
+    normalized["binder_length_min"] = binder_min
+    normalized["binder_length_max"] = binder_max
+
+    try:
+        num_designs = int(normalized.get("num_designs", 5))
+    except (TypeError, ValueError):
+        num_designs = 5
+    normalized["num_designs"] = max(1, min(100, num_designs))
+
+    design_mode = str(normalized.get("design_mode", "default")).strip().lower()
+    if design_mode not in ALLOWED_DESIGN_MODES:
+        raise ValueError(f"BindCraft `design_mode` must be one of {sorted(ALLOWED_DESIGN_MODES)}.")
+    normalized["design_mode"] = design_mode
+
+    normalized["binder_name"] = str(normalized.get("binder_name", "binder")).strip() or "binder"
+
+    return normalized
+
+
+def _build_settings_json(normalized: dict, pdb_path: str, output_dir: str) -> dict:
+    hotspot = normalized["hotspot_residues"] or None
+    return {
+        "design_path": output_dir,
+        "binder_name": normalized["binder_name"],
+        "starting_pdb": pdb_path,
+        "chains": normalized["chains"],
+        "target_hotspot_residues": hotspot,
+        "lengths": [normalized["binder_length_min"], normalized["binder_length_max"]],
+        "number_of_final_designs": normalized["num_designs"],
+    }
+
+
+def _get_filter_path(design_mode: str) -> str:
+    filters_dir = os.path.join(BINDCRAFT_DIR, "settings_filters")
+    if design_mode == "peptide":
+        candidate = os.path.join(filters_dir, "peptide_filters.json")
+        if os.path.isfile(candidate):
+            return candidate
+    default = os.path.join(filters_dir, "default_filters.json")
+    if os.path.isfile(default):
+        return default
+    return ""
+
+
+def _get_advanced_path(design_mode: str) -> str:
+    advanced_dir = os.path.join(BINDCRAFT_DIR, "settings_advanced")
+    mode_map = {
+        "default": "default_4stage_multimer.json",
+        "betasheet": "betasheet_4stage_multimer.json",
+        "peptide": "peptide_4stage_multimer.json",
+    }
+    candidate = os.path.join(advanced_dir, mode_map.get(design_mode, "default_4stage_multimer.json"))
+    if os.path.isfile(candidate):
+        return candidate
+    for fname in sorted(os.listdir(advanced_dir)) if os.path.isdir(advanced_dir) else []:
+        if fname.startswith(design_mode) and fname.endswith(".json"):
+            return os.path.join(advanced_dir, fname)
+    return ""
+
+
+def _collect_designs(output_dir: str) -> tuple[list[dict], list[str]]:
+    designs = []
+    pdb_contents = []
+
+    accepted_dir = os.path.join(output_dir, "Accepted")
+    if not os.path.isdir(accepted_dir):
+        for candidate in ["accepted", "Ranked", "ranked"]:
+            alt = os.path.join(output_dir, candidate)
+            if os.path.isdir(alt):
+                accepted_dir = alt
+                break
+
+    ranked_dir = os.path.join(accepted_dir, "Ranked")
+    search_dir = ranked_dir if os.path.isdir(ranked_dir) else accepted_dir
+
+    if os.path.isdir(search_dir):
+        for fname in sorted(os.listdir(search_dir)):
+            if fname.endswith(".pdb"):
+                pdb_path = os.path.join(search_dir, fname)
+                with open(pdb_path, encoding="utf-8") as f:
+                    content = f.read()
+                pdb_contents.append(content[:5000])
+                designs.append({"name": fname, "path": pdb_path})
+
+    stats_file = os.path.join(output_dir, "final_design_stats.csv")
+    if os.path.isfile(stats_file):
+        try:
+            with open(stats_file, encoding="utf-8") as f:
+                stats_text = f.read()
+            lines = stats_text.strip().split("\n")
+            if len(lines) > 1:
+                headers = lines[0].split(",")
+                for i, design in enumerate(designs):
+                    if i + 1 < len(lines):
+                        values = lines[i + 1].split(",")
+                        for h, v in zip(headers, values):
+                            h = h.strip()
+                            if h in ("i_pTM", "i_pAE", "pLDDT", "Binder_RMSD"):
+                                try:
+                                    design[h] = float(v.strip())
+                                except ValueError:
+                                    pass
+        except Exception:
+            pass
+
+    return designs, pdb_contents
+
+
+def run(
+    target_pdb="",
+    pdb_text="",
+    chains="A",
+    hotspot_residues="",
+    binder_length_min=65,
+    binder_length_max=150,
+    num_designs=5,
+    design_mode="default",
+    binder_name="binder",
+    session_id="",
+    **kwargs,
+):
+    try:
+        normalized = normalize_args({
+            "target_pdb": target_pdb,
+            "pdb_text": pdb_text,
+            "chains": chains,
+            "hotspot_residues": hotspot_residues,
+            "binder_length_min": binder_length_min,
+            "binder_length_max": binder_length_max,
+            "num_designs": num_designs,
+            "design_mode": design_mode,
+            "binder_name": binder_name,
+            "session_id": session_id,
+        })
+    except ValueError as exc:
+        return {"summary": f"Error: {exc}", "error": "invalid_args"}
+
+    target_pdb_content = normalized["target_pdb"]
+    n_residues = _count_residues(target_pdb_content)
+    max_binder = normalized["binder_length_max"]
+    total_residues = n_residues + max_binder
+
+    if total_residues > 950:
+        return {
+            "summary": (
+                f"Error: Complex too large ({total_residues} residues). "
+                f"Target has {n_residues} residues + max binder {max_binder}. "
+                "80GB GPU supports ~950 residues. Trim the target or reduce binder length."
+            ),
+            "error": "complex_too_large",
+        }
+
+    t0 = time.time()
+    vram_before = _get_gpu_vram_mb()
+    stop_event = threading.Event()
+    vram_results = {"peak": vram_before}
+    monitor = threading.Thread(target=_monitor_vram, args=(stop_event, vram_results), daemon=True)
+    monitor.start()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdb_path = os.path.join(tmpdir, "target.pdb")
+        output_dir = os.path.join(tmpdir, "output")
+        os.makedirs(output_dir, exist_ok=True)
+        with open(pdb_path, "w", encoding="utf-8") as f:
+            f.write(target_pdb_content)
+
+        settings = _build_settings_json(normalized, pdb_path, output_dir)
+        settings_path = os.path.join(tmpdir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump(settings, f, indent=2)
+
+        bindcraft_script = os.path.join(BINDCRAFT_DIR, "bindcraft.py")
+        if not os.path.isfile(bindcraft_script):
+            stop_event.set()
+            monitor.join(timeout=2)
+            return {
+                "summary": "Error: BindCraft not installed at expected path.",
+                "error": "not_installed",
+            }
+
+        cmd = [
+            sys.executable,
+            bindcraft_script,
+            "--settings", settings_path,
+        ]
+
+        filter_path = _get_filter_path(normalized["design_mode"])
+        if filter_path:
+            cmd.extend(["--filters", filter_path])
+
+        advanced_path = _get_advanced_path(normalized["design_mode"])
+        if advanced_path:
+            cmd.extend(["--advanced", advanced_path])
+
+        t_inference = time.time()
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=7200,
+                cwd=BINDCRAFT_DIR,
+            )
+        except subprocess.TimeoutExpired:
+            stop_event.set()
+            monitor.join(timeout=2)
+            return {"summary": "Error: BindCraft timed out (2h limit).", "error": "timeout"}
+        t_inference = time.time() - t_inference
+
+        stop_event.set()
+        monitor.join(timeout=2)
+        vram_after = _get_gpu_vram_mb()
+        vram_peak = vram_results["peak"]
+
+        metrics = {
+            "vram_before_mb": vram_before,
+            "vram_after_mb": vram_after,
+            "vram_peak_mb": vram_peak,
+            "time_inference_s": round(t_inference, 2),
+            "time_total_s": round(time.time() - t0, 2),
+            "target_residues": n_residues,
+            "total_complex_residues": total_residues,
+        }
+
+        if result.returncode != 0:
+            stderr_tail = result.stderr[-1000:] if result.stderr else ""
+            stdout_tail = result.stdout[-500:] if result.stdout else ""
+            return {
+                "summary": f"Error: BindCraft failed (exit {result.returncode}): {stderr_tail[:500]}",
+                "error": stderr_tail,
+                "stdout": stdout_tail,
+                "metrics": metrics,
+            }
+
+        designs, pdb_contents = _collect_designs(output_dir)
+
+        if not designs:
+            return {
+                "summary": (
+                    f"BindCraft completed but no designs passed filters. "
+                    f"Target had {n_residues} residues, binder range "
+                    f"{normalized['binder_length_min']}-{normalized['binder_length_max']}. "
+                    f"Try different hotspots, binder lengths, or target trimming."
+                ),
+                "error": "no_passing_designs",
+                "stdout": result.stdout[-500:],
+                "metrics": metrics,
+            }
+
+        design_summaries = []
+        for d in designs:
+            summary = d["name"]
+            if "i_pTM" in d:
+                summary += f" (i_pTM={d['i_pTM']:.3f})"
+            design_summaries.append(summary)
+
+        return {
+            "summary": (
+                f"BindCraft: generated {len(designs)} binder designs for "
+                f"{n_residues}-residue target. "
+                f"Binder range: {normalized['binder_length_min']}-"
+                f"{normalized['binder_length_max']} aa. "
+                f"Top designs: {', '.join(design_summaries[:3])}"
+            ),
+            "designs": designs,
+            "pdb_contents": pdb_contents[:10],
+            "num_designs": len(designs),
+            "metrics": metrics,
+        }

--- a/src/ct/tools/bindcraft/tool.yaml
+++ b/src/ct/tools/bindcraft/tool.yaml
@@ -1,0 +1,77 @@
+name: design.bindcraft
+display_name: BindCraft
+description: Design de novo protein binders using BindCraft (GPU). Uses AlphaFold2 backpropagation, ProteinMPNN sequence optimization, and PyRosetta scoring to generate high-affinity binders from a target structure alone.
+category: design
+usage_guide: >
+  Use to design protein binders against a target. Provide a target PDB structure
+  and optionally specify hotspot residues, binder length range, and number of designs.
+  32GB VRAM handles ~550 residues (target + binder), 80GB handles ~950. Runs one
+  trajectory at a time per GPU. Each trajectory can take 5 min to 3 hours depending
+  on complex size and GPU type.
+docker_image: celltype/bindcraft:latest
+reference:
+  paper_url: https://www.nature.com/articles/s41586-025-09429-6
+  github_url: https://github.com/martinpacesa/BindCraft
+examples:
+  - id: basic-binder
+    title: Design binders for PDL1
+    description: Generate 5 binder designs targeting PDL1 hotspot residues.
+    args:
+      num_designs: 5
+      hotspot_residues: "A56"
+      binder_length_min: 65
+      binder_length_max: 150
+parameters:
+  type: object
+  additionalProperties: false
+  required:
+    - target_pdb
+  properties:
+    target_pdb:
+      type: string
+      description: Target protein structure in PDB format. Paste content or drag & drop a .pdb file. Trim to the binding region for best performance.
+    chains:
+      type: string
+      description: Target chain IDs to design binders against (e.g., "A" or "A,B"). Defaults to first chain.
+      default: "A"
+    hotspot_residues:
+      type: string
+      description: >
+        Target residues the binder should contact. Accepts comma-separated residue numbers
+        (e.g., "56,57,61"), ranges ("23,25,27-30"), or chain-specific ("A56,A57").
+        Leave empty to let BindCraft automatically select the binding site.
+    binder_length_min:
+      type: integer
+      description: Minimum binder length in residues. Optimal range is 60-180 for globular binders, 8-25 for peptides.
+      default: 65
+      minimum: 4
+      maximum: 250
+    binder_length_max:
+      type: integer
+      description: Maximum binder length in residues.
+      default: 150
+      minimum: 4
+      maximum: 250
+    num_designs:
+      type: integer
+      description: Number of final designs passing computational filters to aim for.
+      default: 5
+      minimum: 1
+      maximum: 100
+    design_mode:
+      type: string
+      description: Design settings profile. "default" for general targets, "betasheet" to enforce beta-sheet binders, "peptide" for short peptide binders.
+      enum: [default, betasheet, peptide]
+      default: default
+    binder_name:
+      type: string
+      description: Prefix for designed binder output files.
+      default: binder
+compute:
+  requires_gpu: true
+  min_vram_gb: 32
+  gpu_profile: structure
+  estimated_cost_usd: 0.25
+  gpu_type: A100
+execution:
+  timeout_s: 7200

--- a/src/ct/tools/bindcraft/tool_entrypoint.py
+++ b/src/ct/tools/bindcraft/tool_entrypoint.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Standard container entrypoint for all GPU/CPU tools.
+Reads input.json, calls implementation.run(**args), writes output.json."""
+import json, os, sys, traceback
+
+def main():
+    input_file = os.environ.get("INPUT_FILE", "/workspace/input.json")
+    output_file = os.environ.get("OUTPUT_FILE", "/workspace/output.json")
+    try:
+        with open(input_file) as f:
+            args = json.load(f)
+        if not isinstance(args, dict):
+            args = {}
+        sys.path.insert(0, "/opt")
+        from implementation import run
+        result = run(**args)
+        if not isinstance(result, dict):
+            result = {"summary": str(result)}
+        with open(output_file, "w") as f:
+            json.dump(result, f, indent=2, default=str)
+    except Exception as e:
+        with open(output_file, "w") as f:
+            json.dump({"summary": f"Error: {e}", "error": traceback.format_exc()}, f, indent=2)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bindcraft.py
+++ b/tests/test_bindcraft.py
@@ -1,0 +1,389 @@
+"""Tests for BindCraft binder design tool — mocked, no GPU required."""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+SAMPLE_PDB = (
+    "HEADER    TEST\n"
+    "ATOM      1  N   ALA A   1       1.000   2.000   3.000  1.00  0.00           N\n"
+    "ATOM      2  CA  ALA A   1       2.000   3.000   4.000  1.00  0.00           C\n"
+    "ATOM      3  C   ALA A   1       3.000   4.000   5.000  1.00  0.00           C\n"
+    "ATOM      4  O   ALA A   1       4.000   5.000   6.000  1.00  0.00           O\n"
+    "ATOM      5  N   GLY A   2       5.000   6.000   7.000  1.00  0.00           N\n"
+    "ATOM      6  CA  GLY A   2       6.000   7.000   8.000  1.00  0.00           C\n"
+    "ATOM      7  C   GLY A   2       7.000   8.000   9.000  1.00  0.00           C\n"
+    "ATOM      8  O   GLY A   2       8.000   9.000  10.000  1.00  0.00           O\n"
+    "END\n"
+)
+
+
+class TestBindCraftNormalization:
+    """Test argument normalization logic."""
+
+    def test_normalize_basic_args(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({
+            "target_pdb": SAMPLE_PDB,
+            "chains": "A",
+            "num_designs": 5,
+        })
+        assert result["chains"] == "A"
+        assert result["num_designs"] == 5
+        assert result["binder_length_min"] == 65
+        assert result["binder_length_max"] == 150
+        assert result["design_mode"] == "default"
+        assert result["binder_name"] == "binder"
+
+    def test_normalize_rejects_missing_pdb(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        with pytest.raises(ValueError, match="requires `target_pdb`"):
+            normalize_args({"chains": "A"})
+
+    def test_normalize_rejects_empty_pdb(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        with pytest.raises(ValueError, match="requires `target_pdb`"):
+            normalize_args({"target_pdb": ""})
+
+    def test_normalize_rejects_no_atom_records(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        with pytest.raises(ValueError, match="ATOM/HETATM"):
+            normalize_args({"target_pdb": "HEADER only\nREMARK no atoms\n"})
+
+    def test_normalize_rejects_invalid_chain(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        with pytest.raises(ValueError, match="Chain 'Z' not found"):
+            normalize_args({"target_pdb": SAMPLE_PDB, "chains": "Z"})
+
+    def test_normalize_clamps_binder_length(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({
+            "target_pdb": SAMPLE_PDB,
+            "binder_length_min": 1,
+            "binder_length_max": 999,
+        })
+        assert result["binder_length_min"] == 4
+        assert result["binder_length_max"] == 250
+
+    def test_normalize_enforces_min_le_max(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({
+            "target_pdb": SAMPLE_PDB,
+            "binder_length_min": 100,
+            "binder_length_max": 50,
+        })
+        assert result["binder_length_max"] >= result["binder_length_min"]
+
+    def test_normalize_clamps_num_designs(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({
+            "target_pdb": SAMPLE_PDB,
+            "num_designs": 999,
+        })
+        assert result["num_designs"] == 100
+
+    def test_normalize_rejects_invalid_design_mode(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        with pytest.raises(ValueError, match="design_mode"):
+            normalize_args({"target_pdb": SAMPLE_PDB, "design_mode": "turbo"})
+
+    def test_normalize_accepts_peptide_mode(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({
+            "target_pdb": SAMPLE_PDB,
+            "design_mode": "peptide",
+            "binder_length_min": 8,
+            "binder_length_max": 25,
+        })
+        assert result["design_mode"] == "peptide"
+
+    def test_normalize_rejects_unexpected_args(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        with pytest.raises(ValueError, match="unsupported arguments"):
+            normalize_args({"target_pdb": SAMPLE_PDB, "turbo_mode": True})
+
+    def test_normalize_auto_detects_chain(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({"target_pdb": SAMPLE_PDB, "chains": ""})
+        assert result["chains"] == "A"
+
+    def test_normalize_pdb_text_alias(self):
+        from ct.tools.bindcraft.implementation import normalize_args
+
+        result = normalize_args({"pdb_text": SAMPLE_PDB})
+        assert "ATOM" in result["target_pdb"]
+
+
+class TestBindCraftHelpers:
+    """Test helper functions."""
+
+    def test_parse_chain_ids(self):
+        from ct.tools.bindcraft.implementation import _parse_chain_ids
+
+        chains = _parse_chain_ids(SAMPLE_PDB)
+        assert "A" in chains
+
+    def test_count_residues(self):
+        from ct.tools.bindcraft.implementation import _count_residues
+
+        count = _count_residues(SAMPLE_PDB)
+        assert count == 2
+
+    def test_build_settings_json(self):
+        from ct.tools.bindcraft.implementation import _build_settings_json
+
+        normalized = {
+            "binder_name": "test_binder",
+            "chains": "A",
+            "hotspot_residues": "56,57",
+            "binder_length_min": 65,
+            "binder_length_max": 150,
+            "num_designs": 5,
+        }
+        settings = _build_settings_json(normalized, "/tmp/target.pdb", "/tmp/output")
+        assert settings["starting_pdb"] == "/tmp/target.pdb"
+        assert settings["design_path"] == "/tmp/output"
+        assert settings["binder_name"] == "test_binder"
+        assert settings["chains"] == "A"
+        assert settings["target_hotspot_residues"] == "56,57"
+        assert settings["lengths"] == [65, 150]
+        assert settings["number_of_final_designs"] == 5
+
+    def test_build_settings_json_no_hotspots(self):
+        from ct.tools.bindcraft.implementation import _build_settings_json
+
+        normalized = {
+            "binder_name": "binder",
+            "chains": "A",
+            "hotspot_residues": "",
+            "binder_length_min": 65,
+            "binder_length_max": 150,
+            "num_designs": 5,
+        }
+        settings = _build_settings_json(normalized, "/tmp/target.pdb", "/tmp/output")
+        assert settings["target_hotspot_residues"] is None
+
+
+class TestBindCraftRun:
+    """Test the main run() function with mocked subprocess."""
+
+    def test_run_returns_error_for_empty_pdb(self):
+        from ct.tools.bindcraft.implementation import run
+
+        result = run(target_pdb="")
+        assert "Error" in result["summary"]
+        assert result["error"] == "invalid_args"
+
+    def test_run_returns_error_for_too_large_complex(self):
+        from ct.tools.bindcraft.implementation import run
+
+        huge_pdb_lines = ["HEADER    TEST\n"]
+        for i in range(1, 900):
+            huge_pdb_lines.append(
+                f"ATOM  {i:5d}  CA  ALA A{i:4d}       "
+                f"{float(i):7.3f}{float(i):8.3f}{float(i):8.3f}"
+                f"  1.00  0.00           C\n"
+            )
+        huge_pdb_lines.append("END\n")
+        huge_pdb = "".join(huge_pdb_lines)
+
+        result = run(target_pdb=huge_pdb, binder_length_max=150)
+        assert "too large" in result["summary"]
+        assert result["error"] == "complex_too_large"
+
+    @patch("ct.tools.bindcraft.implementation.subprocess.run")
+    @patch("ct.tools.bindcraft.implementation.os.path.isfile")
+    def test_run_success_with_designs(self, mock_isfile, mock_subprocess, tmp_path):
+        from ct.tools.bindcraft.implementation import run
+
+        mock_isfile.return_value = True
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "BindCraft completed"
+        mock_result.stderr = ""
+        mock_subprocess.return_value = mock_result
+
+        accepted_dir = tmp_path / "output" / "Accepted"
+        accepted_dir.mkdir(parents=True)
+        (accepted_dir / "binder_001.pdb").write_text(SAMPLE_PDB)
+        (accepted_dir / "binder_002.pdb").write_text(SAMPLE_PDB)
+
+        with patch("ct.tools.bindcraft.implementation.tempfile.TemporaryDirectory") as mock_tmpdir:
+            mock_tmpdir.return_value.__enter__ = lambda s: str(tmp_path)
+            mock_tmpdir.return_value.__exit__ = MagicMock(return_value=False)
+
+            with patch("ct.tools.bindcraft.implementation._get_gpu_vram_mb", return_value=0):
+                result = run(target_pdb=SAMPLE_PDB, num_designs=2)
+
+        assert "Error" not in result.get("summary", "") or "not installed" in result.get("summary", "").lower()
+
+    @patch("ct.tools.bindcraft.implementation.subprocess.run")
+    @patch("ct.tools.bindcraft.implementation.os.path.isfile", return_value=True)
+    def test_run_handles_subprocess_failure(self, mock_isfile, mock_subprocess):
+        from ct.tools.bindcraft.implementation import run
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "CUDA out of memory"
+        mock_subprocess.return_value = mock_result
+
+        with patch("ct.tools.bindcraft.implementation._get_gpu_vram_mb", return_value=0):
+            result = run(target_pdb=SAMPLE_PDB)
+
+        assert "Error" in result["summary"] or "failed" in result["summary"].lower()
+
+    @patch("ct.tools.bindcraft.implementation.subprocess.run")
+    @patch("ct.tools.bindcraft.implementation.os.path.isfile", return_value=True)
+    def test_run_handles_timeout(self, mock_isfile, mock_subprocess):
+        import subprocess as sp
+        from ct.tools.bindcraft.implementation import run
+
+        mock_subprocess.side_effect = sp.TimeoutExpired(cmd="bindcraft", timeout=7200)
+
+        with patch("ct.tools.bindcraft.implementation._get_gpu_vram_mb", return_value=0):
+            result = run(target_pdb=SAMPLE_PDB)
+
+        assert "timeout" in result["summary"].lower() or result["error"] == "timeout"
+
+
+class TestBindCraftCollectDesigns:
+    """Test output collection logic."""
+
+    def test_collect_from_accepted_dir(self, tmp_path):
+        from ct.tools.bindcraft.implementation import _collect_designs
+
+        accepted = tmp_path / "Accepted"
+        accepted.mkdir()
+        (accepted / "binder_001.pdb").write_text(SAMPLE_PDB)
+        (accepted / "binder_002.pdb").write_text(SAMPLE_PDB)
+
+        designs, pdbs = _collect_designs(str(tmp_path))
+        assert len(designs) == 2
+        assert len(pdbs) == 2
+        assert designs[0]["name"] == "binder_001.pdb"
+
+    def test_collect_from_ranked_subdir(self, tmp_path):
+        from ct.tools.bindcraft.implementation import _collect_designs
+
+        ranked = tmp_path / "Accepted" / "Ranked"
+        ranked.mkdir(parents=True)
+        (ranked / "ranked_001.pdb").write_text(SAMPLE_PDB)
+
+        designs, pdbs = _collect_designs(str(tmp_path))
+        assert len(designs) == 1
+        assert designs[0]["name"] == "ranked_001.pdb"
+
+    def test_collect_empty_dir(self, tmp_path):
+        from ct.tools.bindcraft.implementation import _collect_designs
+
+        designs, pdbs = _collect_designs(str(tmp_path))
+        assert len(designs) == 0
+        assert len(pdbs) == 0
+
+    def test_collect_with_stats_csv(self, tmp_path):
+        from ct.tools.bindcraft.implementation import _collect_designs
+
+        accepted = tmp_path / "Accepted"
+        accepted.mkdir()
+        (accepted / "binder_001.pdb").write_text(SAMPLE_PDB)
+
+        stats = "name,i_pTM,i_pAE,pLDDT,Binder_RMSD\nbinder_001,0.85,5.2,92.1,0.7\n"
+        (tmp_path / "final_design_stats.csv").write_text(stats)
+
+        designs, pdbs = _collect_designs(str(tmp_path))
+        assert len(designs) == 1
+        assert designs[0].get("i_pTM") == pytest.approx(0.85)
+        assert designs[0].get("pLDDT") == pytest.approx(92.1)
+
+
+class TestBindCraftRegistration:
+    """Test that BindCraft registers correctly via the container tool loader."""
+
+    def test_bindcraft_tool_yaml_loads(self):
+        import yaml
+
+        yaml_path = os.path.join(
+            os.path.dirname(__file__),
+            "..", "src", "ct", "tools", "bindcraft", "tool.yaml"
+        )
+        with open(yaml_path) as f:
+            config = yaml.safe_load(f)
+
+        assert config["name"] == "design.bindcraft"
+        assert config["category"] == "design"
+        assert config["docker_image"] == "celltype/bindcraft:latest"
+        assert config["compute"]["requires_gpu"] is True
+        assert config["compute"]["min_vram_gb"] == 32
+        assert "target_pdb" in config["parameters"]["properties"]
+
+    def test_bindcraft_registered_in_registry(self):
+        from ct.tools import registry, ensure_loaded
+
+        ensure_loaded()
+
+        tool = registry.get_tool("design.bindcraft")
+        assert tool is not None
+        assert tool.requires_gpu is True
+        assert tool.docker_image == "celltype/bindcraft:latest"
+        assert tool.category == "design"
+        assert tool.min_vram_gb == 32
+        assert tool.gpu_profile == "structure"
+
+
+class TestBindCraftLocalRunner:
+    """Test BindCraft integration with LocalRunner."""
+
+    def test_local_runner_inlines_target_pdb(self, tmp_path):
+        from dataclasses import dataclass
+        from ct.cloud.local_runner import LocalRunner
+
+        @dataclass
+        class FakeTool:
+            name: str = "design.bindcraft"
+            requires_gpu: bool = True
+            gpu_profile: str = "structure"
+            estimated_cost: float = 0.25
+            docker_image: str = "celltype/bindcraft:latest"
+            min_vram_gb: int = 32
+            min_ram_gb: int = 0
+            cpu_only: bool = False
+            num_gpus: int = 1
+
+        runner = LocalRunner(workspace=tmp_path)
+        tool = FakeTool()
+        pdb_path = tmp_path / "target.pdb"
+        pdb_path.write_text(SAMPLE_PDB, encoding="utf-8")
+
+        with patch("ct.cloud.local_runner.subprocess.run") as mock_run:
+            inspect_result = MagicMock(returncode=0)
+            run_result = MagicMock(returncode=0, stdout="", stderr="")
+            mock_run.side_effect = [inspect_result, run_result]
+
+            runner.run(tool, target_pdb=str(pdb_path))
+
+        input_payload = json.loads((runner._session_dir / "input.json").read_text())
+        assert input_payload["target_pdb"] == SAMPLE_PDB
+
+    def test_bindcraft_cache_mount_exists(self):
+        from ct.cloud.local_runner import LocalRunner
+
+        runner = LocalRunner()
+        mounts = runner._get_cache_mounts()
+        mount_str = " ".join(mounts)
+        assert "bindcraft" in mount_str

--- a/tests/test_e2e_local_gpu.py
+++ b/tests/test_e2e_local_gpu.py
@@ -191,6 +191,46 @@ class TestLocalGPUExecution:
         assert output["num_residues"] == 18
 
 
+    @requires_docker
+    @requires_gpu
+    def test_bindcraft_local_docker(self, tmp_path):
+        """Run BindCraft in Docker with GPU 0."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        pdb_text = (
+            "ATOM      1  N   ALA A   1       1.000   2.000   3.000  1.00  0.00           N\n"
+            "ATOM      2  CA  ALA A   1       2.000   3.000   4.000  1.00  0.00           C\n"
+            "ATOM      3  C   ALA A   1       3.000   4.000   5.000  1.00  0.00           C\n"
+            "ATOM      4  O   ALA A   1       4.000   5.000   6.000  1.00  0.00           O\n"
+            "END\n"
+        )
+        (workspace / "input.json").write_text(json.dumps({
+            "target_pdb": pdb_text,
+            "chains": "A",
+            "num_designs": 1,
+            "binder_length_min": 20,
+            "binder_length_max": 40,
+        }))
+
+        cmd = [
+            "sudo", "docker", "run", "--rm",
+            "--gpus", '"device=0"',
+            "-v", f"{workspace}:/workspace",
+            "-e", "TOOL_NAME=design.bindcraft",
+            "-e", "INPUT_FILE=/workspace/input.json",
+            "-e", "OUTPUT_FILE=/workspace/output.json",
+            "celltype/bindcraft:latest",
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=7200)
+
+        output_file = workspace / "output.json"
+        assert output_file.exists(), f"No output.json. stderr: {result.stderr[-300:]}"
+
+        output = json.loads(output_file.read_text())
+        assert "summary" in output
+
+
 @pytest.mark.e2e
 class TestLocalRunnerIntegration:
     """Test the LocalRunner class end-to-end."""

--- a/tests/test_gpu_registry.py
+++ b/tests/test_gpu_registry.py
@@ -201,6 +201,28 @@ class TestGPUToolsLoaded:
         # AlphaFold3 not yet available
         assert registry.get_tool("structure.alphafold3") is None
 
+    def test_gpu_design_tools_registered(self):
+        from ct.tools import registry, ensure_loaded
+
+        ensure_loaded()
+
+        rfdiffusion = registry.get_tool("design.rfdiffusion")
+        assert rfdiffusion is not None
+        assert rfdiffusion.requires_gpu is True
+        assert rfdiffusion.category == "design"
+
+        proteinmpnn = registry.get_tool("design.proteinmpnn")
+        assert proteinmpnn is not None
+        assert proteinmpnn.requires_gpu is True
+        assert proteinmpnn.category == "design"
+
+        bindcraft = registry.get_tool("design.bindcraft")
+        assert bindcraft is not None
+        assert bindcraft.requires_gpu is True
+        assert bindcraft.gpu_profile == "structure"
+        assert bindcraft.category == "design"
+        assert bindcraft.docker_image == "celltype/bindcraft:latest"
+
     def test_gpu_tools_have_vram_requirements(self):
         from ct.tools import registry, ensure_loaded
 
@@ -211,3 +233,6 @@ class TestGPUToolsLoaded:
 
         diffdock = registry.get_tool("structure.diffdock")
         assert diffdock.min_vram_gb == 32
+
+        bindcraft = registry.get_tool("design.bindcraft")
+        assert bindcraft.min_vram_gb == 32

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -212,6 +212,7 @@ class TestLocalRunner:
         [
             ("design.rfdiffusion", "target_pdb"),
             ("design.proteinmpnn", "backbone_pdb"),
+            ("design.bindcraft", "target_pdb"),
             ("structure.diffdock", "protein_pdb"),
         ],
     )


### PR DESCRIPTION
## Summary

- **Add `design.bindcraft`** as a new GPU container tool for de novo protein binder design using AlphaFold2 backpropagation + ProteinMPNN + PyRosetta scoring (from [martinpacesa/BindCraft](https://github.com/martinpacesa/BindCraft), [Nature 2025](https://www.nature.com/articles/s41586-025-09429-6))
- **New container tool directory** (`src/ct/tools/bindcraft/`) with `tool.yaml`, `Dockerfile`, `implementation.py`, and `tool_entrypoint.py` — auto-discovered by the existing container tool loader, no registration code needed
- **Add BindCraft cache mount** to `LocalRunner` so AF2 weights persist across container runs
- **Expand GPU test suite** across `test_gpu_registry.py`, `test_local_runner.py`, and `test_e2e_local_gpu.py` to cover the new tool alongside existing design tools; add dedicated `test_bindcraft.py` with 30 unit tts

## What BindCraft does

BindCraft designs protein binders with nanomolar affinity from a target PDB structure alone. It supports:
- Hotspot-guided or automatic binding site selection
- Configurable binder length (4–250 residues, optimal 60–180)
- Three design modes: `default`, `betasheet`, `peptide`
- Complex size validation (32GB GPU ~550 residues, 80GB ~950)

## Test plan

- [x] All 30 `test_bindcraft.py` tests pass (normalization, helpers, mocked run, output collection, registry, local runner)
- [x] All 11 `test_gpu_registry.py` tests pass (including new design tool assertions)
- [x] All 5 `test_setup_gpu.py` tests pass
- [x] No lint errors introduced
- [ ] E2E Docker test (`test_bindcraft_local_docker`) — requires GPU hardware