### PR TITLE
fix(cli): avoid importing trace subsystem for release-check --no-trace

### DIFF
--- a/src/ct/cli.py
+++ b/src/ct/cli.py
@@ -1113,7 +1113,6 @@ def release_check_cmd(
     """Run a production release gate: doctor + tests + benchmark + trace diagnostics."""
     from ct.agent.config import Config
     from ct.agent.doctor import has_errors, run_checks, to_table
-    from ct.agent.trace import TraceLogger
     from ct.kb.benchmarks import BenchmarkSuite
 
     failed = False
@@ -1181,21 +1180,32 @@ def release_check_cmd(
             failed = True
 
     if run_trace:
-        resolved_trace = trace_path or _latest_trace_path()
-        if resolved_trace is None or not resolved_trace.exists():
-            msg = "No trace file found for diagnostics."
-            if trace_required:
-                console.print(f"[red]{msg}[/red]")
-                failed = True
-            else:
-                console.print(f"[yellow]{msg}[/yellow]")
+        try:
+            from ct.agent.trace import TraceLogger
+        except ImportError:
+            console.print(
+                "[red]Trace diagnostics requested, but ct.agent.trace is unavailable.[/red]"
+            )
+            failed = True
         else:
-            trace = TraceLogger.load(resolved_trace)
-            diag = trace.diagnostics()
-            _print_trace_diagnostics_table(diag, title=f"Trace Diagnostics: {resolved_trace.name}")
-            if _trace_has_issues(diag):
-                console.print("[red]Trace diagnostics detected integrity issues.[/red]")
-                failed = True
+            resolved_trace = trace_path or _latest_trace_path()
+            if resolved_trace is None or not resolved_trace.exists():
+                msg = "No trace file found for diagnostics."
+                if trace_required:
+                    console.print(f"[red]{msg}[/red]")
+                    failed = True
+                else:
+                    console.print(f"[yellow]{msg}[/yellow]")
+            else:
+                trace = TraceLogger.load(resolved_trace)
+                diag = trace.diagnostics()
+                _print_trace_diagnostics_table(
+                    diag,
+                    title=f"Trace Diagnostics: {resolved_trace.name}",
+                )
+                if _trace_has_issues(diag):
+                    console.print("[red]Trace diagnostics detected integrity issues.[/red]")
+                    failed = True
 
     if include_live:
         smoke_env = dict(os.environ)


### PR DESCRIPTION
## Summary

This fixes `release-check --no-trace` crashing due to an unconditional trace import.

Currently, `release_check_cmd` imports `TraceLogger` even when `--no-trace` is passed. Since the trace subsystem may be unavailable, the command fails before the flag can take effect.

## What changed

- removed the unconditional `ct.agent.trace` import from `release_check_cmd`
- lazily imported `TraceLogger` only when `run_trace` is enabled
- added a clear error message when trace diagnostics are requested but the trace subsystem is unavailable

## Why

`--no-trace` should allow release checks to run without requiring trace support. Right now the import happens too early, so the flag is ineffective.

## Result

- `ct release-check --no-trace` no longer imports trace code
- users can run release checks without the trace subsystem
- traced behavior remains unchanged when tracing is enabled