### PR TITLE
Add ImmuneBuilder structure tool for antibody, nanobody, and TCR prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,6 @@ busco_downloads/
 *.mafft.clipkit
 .env
 .claude/worktrees/
-
-
-
+.codex/
 
 .vercel

--- a/src/ct/agent/trace.py
+++ b/src/ct/agent/trace.py
@@ -1,0 +1,272 @@
+"""Compatibility trace logger used by CLI diagnostics and exports."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+class TraceLogger:
+    """Small JSONL trace helper with enough API for CLI tooling."""
+
+    def __init__(self, session_id: str, events: list[dict[str, Any]] | None = None):
+        self.session_id = session_id
+        self.events: list[dict[str, Any]] = list(events or [])
+
+    @staticmethod
+    def traces_dir() -> Path:
+        """Use the shared sessions directory where trace JSONL files already live."""
+
+        directory = Path.home() / ".ct" / "sessions"
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+    def _append(self, event_type: str, **payload: Any) -> None:
+        payload.setdefault("timestamp", time.time())
+        payload["type"] = event_type
+        self.events.append(payload)
+
+    def query_start(self, query: str, model: str = "") -> None:
+        self._append(
+            "query_start",
+            session_id=self.session_id,
+            query=query,
+            model=model,
+        )
+
+    def plan(self, steps: list[Any], query: str = "") -> None:
+        self._append("plan", query=query, steps=steps)
+
+    def step_start(self, step_id: int, tool: str, tool_args: dict[str, Any] | None = None) -> None:
+        self._append("step_start", step_id=step_id, tool=tool, tool_args=tool_args or {})
+
+    def step_complete(
+        self,
+        step_id: int,
+        tool: str,
+        result: dict[str, Any] | None = None,
+        duration_s: float = 0.0,
+    ) -> None:
+        self._append(
+            "step_complete",
+            step_id=step_id,
+            tool=tool,
+            result=result or {},
+            duration_s=duration_s,
+        )
+
+    def step_fail(
+        self,
+        step_id: int,
+        tool: str,
+        error: str,
+        duration_s: float = 0.0,
+    ) -> None:
+        self._append(
+            "step_fail",
+            step_id=step_id,
+            tool=tool,
+            error=error,
+            duration_s=duration_s,
+        )
+
+    def step_retry(self, step_id: int, tool: str, reason: str = "") -> None:
+        self._append("step_retry", step_id=step_id, tool=tool, reason=reason)
+
+    def synthesize_start(self) -> None:
+        self._append("synthesize_start")
+
+    def synthesize_end(self, token_count: int = 0, duration_s: float = 0.0) -> None:
+        self._append(
+            "synthesize_end",
+            token_count=token_count,
+            duration_s=duration_s,
+        )
+
+    def query_end(
+        self,
+        iterations: int = 1,
+        total_steps: int = 0,
+        completed_steps: int = 0,
+        failed_steps: int = 0,
+        duration_s: float = 0.0,
+        cost_usd: float = 0.0,
+    ) -> None:
+        self._append(
+            "query_end",
+            iterations=iterations,
+            total_steps=total_steps,
+            completed_steps=completed_steps,
+            failed_steps=failed_steps,
+            duration_s=duration_s,
+            cost_usd=cost_usd,
+        )
+
+    def save(self, path: Path | str | None = None) -> Path:
+        target = Path(path) if path is not None else self.traces_dir() / f"{self.session_id}.trace.jsonl"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "w", encoding="utf-8") as handle:
+            for event in self.events:
+                handle.write(json.dumps(event, default=str) + "\n")
+        return target
+
+    @classmethod
+    def load(cls, path: Path | str) -> "TraceLogger":
+        target = Path(path)
+        events: list[dict[str, Any]] = []
+        with open(target, "r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                events.append(json.loads(line))
+
+        session_id = target.stem.replace(".trace", "")
+        for event in events:
+            if event.get("type") == "query_start" and event.get("session_id"):
+                session_id = str(event["session_id"])
+                break
+
+        return cls(session_id=session_id, events=events)
+
+    def diagnostics(self) -> dict[str, Any]:
+        queries: list[dict[str, Any]] = []
+        current: dict[str, Any] | None = None
+
+        for event in self.events:
+            event_type = event.get("type", "")
+
+            if event_type == "query_start":
+                current = {
+                    "query_number": len(queries) + 1,
+                    "query": event.get("query", ""),
+                    "closed": False,
+                    "plan_count": 0,
+                    "activity_count": 0,
+                    "step_start_count": 0,
+                    "step_complete_count": 0,
+                    "step_fail_count": 0,
+                    "step_retry_count": 0,
+                    "synthesize_start_count": 0,
+                    "synthesize_end_count": 0,
+                }
+                queries.append(current)
+                continue
+
+            if current is None:
+                continue
+
+            if event_type == "text":
+                content = event.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    current["activity_count"] += 1
+            elif event_type == "plan":
+                current["plan_count"] += 1
+                current["activity_count"] += 1
+            elif event_type in {"step_start", "tool_start"}:
+                current["step_start_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "step_complete":
+                current["step_complete_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "tool_result":
+                if event.get("is_error"):
+                    current["step_fail_count"] += 1
+                else:
+                    current["step_complete_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "step_fail":
+                current["step_fail_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "step_retry":
+                current["step_retry_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "synthesize_start":
+                current["synthesize_start_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "synthesize_end":
+                current["synthesize_end_count"] += 1
+                current["activity_count"] += 1
+            elif event_type == "query_end":
+                current["closed"] = True
+
+        query_start_count = sum(1 for event in self.events if event.get("type") == "query_start")
+        query_end_count = sum(1 for event in self.events if event.get("type") == "query_end")
+
+        unclosed_queries = [
+            query["query_number"] for query in queries if not query["closed"]
+        ]
+        queries_with_failures = [
+            query["query_number"] for query in queries if query["step_fail_count"] > 0
+        ]
+        queries_with_no_plan = [
+            query["query_number"]
+            for query in queries
+            if query["plan_count"] == 0 and query["activity_count"] == 0
+        ]
+        queries_with_no_completion = [
+            query["query_number"]
+            for query in queries
+            if not query["closed"] or query["activity_count"] == 0
+        ]
+        queries_with_synthesis_mismatch = [
+            query["query_number"]
+            for query in queries
+            if query["synthesize_start_count"] != query["synthesize_end_count"]
+        ]
+
+        return {
+            "session_id": self.session_id,
+            "event_count": len(self.events),
+            "query_count": len(queries),
+            "query_start_count": query_start_count,
+            "query_end_count": query_end_count,
+            "total_step_start_count": sum(query["step_start_count"] for query in queries),
+            "total_step_complete_count": sum(
+                query["step_complete_count"] for query in queries
+            ),
+            "total_step_fail_count": sum(query["step_fail_count"] for query in queries),
+            "total_step_retry_count": sum(query["step_retry_count"] for query in queries),
+            "unclosed_queries": unclosed_queries,
+            "queries_with_failures": queries_with_failures,
+            "queries_with_no_plan": queries_with_no_plan,
+            "queries_with_no_completion": queries_with_no_completion,
+            "queries_with_synthesis_mismatch": queries_with_synthesis_mismatch,
+            "queries": queries,
+        }
+
+    def query_summaries(self) -> list[dict[str, Any]]:
+        summaries = []
+        for query in self.diagnostics()["queries"]:
+            summaries.append(
+                {
+                    "query_number": query["query_number"],
+                    "query": query["query"],
+                    "closed": query["closed"],
+                    "step_start_count": query["step_start_count"],
+                    "step_complete_count": query["step_complete_count"],
+                    "step_fail_count": query["step_fail_count"],
+                    "step_retry_count": query["step_retry_count"],
+                }
+            )
+        return summaries
+
+    def to_text(self) -> str:
+        lines = []
+        for event in self.events:
+            event_type = event.get("type", "")
+            if event_type == "query_start":
+                lines.append(f"query_start: {event.get('query', '')}")
+            elif event_type == "plan":
+                lines.append("plan")
+            elif event_type in {"step_start", "tool_start"}:
+                lines.append(f"{event_type}: {event.get('tool', '')}")
+            elif event_type in {"step_complete", "tool_result"}:
+                lines.append(f"{event_type}: {event.get('tool', '')}")
+            elif event_type == "query_end":
+                lines.append("query_end")
+            else:
+                lines.append(event_type)
+        return "\n".join(lines)

--- a/src/ct/agent/trace.py
+++ b/src/ct/agent/trace.py
@@ -209,7 +209,9 @@ class TraceLogger:
         queries_with_no_completion = [
             query["query_number"]
             for query in queries
-            if not query["closed"] or query["activity_count"] == 0
+            if not query["closed"]
+            or query["activity_count"] == 0
+            or query["step_start_count"] > query["step_complete_count"] + query["step_fail_count"]
         ]
         queries_with_synthesis_mismatch = [
             query["query_number"]
@@ -265,6 +267,10 @@ class TraceLogger:
                 lines.append(f"{event_type}: {event.get('tool', '')}")
             elif event_type in {"step_complete", "tool_result"}:
                 lines.append(f"{event_type}: {event.get('tool', '')}")
+            elif event_type == "text":
+                content = event.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    lines.append(f"text: {content}")
             elif event_type == "query_end":
                 lines.append("query_end")
             else:

--- a/src/ct/cli.py
+++ b/src/ct/cli.py
@@ -684,6 +684,54 @@ def _pull_colabfold_databases(console):
     console.print("MSA-Search will use local MMseqs2 for fast, reliable homology search.")
 
 
+def _tool_pull_test_input(tool_name: str) -> dict[str, object]:
+    """Return a schema-valid warmup payload that reaches model initialization."""
+
+    if tool_name == "structure.immunebuilder":
+        return {
+            "mode": "nanobody",
+            "heavy_chain": (
+                "QVQLVESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAIYSGGSTYYADSVKGRFTISRDNSKNTLY"
+                "LQMNSLRAEDTAVYYCAR"
+            ),
+        }
+    if "diffdock" in tool_name:
+        return {
+            "protein_pdb": "ATOM      1  CA  ALA A   1       0.0   0.0   0.0  1.00  0.00\nEND",
+            "ligand_smiles": "C",
+            "num_poses": 1,
+        }
+    if "proteinmpnn" in tool_name:
+        return {
+            "backbone_pdb": (
+                "ATOM      1  N   ALA A   1       0.0   0.0   0.0  1.00  0.00\n"
+                "ATOM      2  CA  ALA A   1       1.5   0.0   0.0  1.00  0.00\n"
+                "ATOM      3  C   ALA A   1       2.5   1.2   0.0  1.00  0.00\n"
+                "ATOM      4  O   ALA A   1       2.2   2.4   0.0  1.00  0.00\n"
+                "END"
+            ),
+            "num_sequences": 1,
+        }
+    if "rfdiffusion" in tool_name:
+        return {
+            "target_pdb": "ATOM      1  CA  ALA A   1       0.0   0.0   0.0  1.00  0.00\nEND",
+            "num_designs": 1,
+        }
+    if "evo2" in tool_name and "protein" in tool_name:
+        return {"target_function": "test"}
+    if "evo2" in tool_name:
+        return {"dna_sequence": "ATG"}
+    if "genmol" in tool_name:
+        return {"scaffold_smiles": "C", "num_molecules": 1}
+    if "molmim" in tool_name:
+        return {"input_smiles": "C", "num_variants": 1}
+    if "msa" in tool_name:
+        return {"sequence": "MKWV"}
+    if "multimer" in tool_name:
+        return {"sequences": ["MK", "WV"]}
+    return {"sequence": "MKWV"}
+
+
 @tool_app.command("pull")
 def tool_pull(
     tool_name: str = typer.Argument(..., help="Tool name (e.g., structure.esmfold)"),
@@ -750,18 +798,13 @@ def tool_pull(
 
     if force:
         console.print(f"[bold]Building {docker_image}...[/bold]")
-        # Copy tool_entrypoint.py if missing
-        entrypoint = docker_dir / "tool_entrypoint.py"
-        if not entrypoint.exists():
-            src = tools_dir / "tool_entrypoint.py"
-            if src.exists():
-                import shutil
-                shutil.copy2(src, entrypoint)
+        from ct.cloud.local_runner import tool_docker_build_context
 
-        result = subprocess.run(
-            ["docker", "build", "-t", docker_image, str(docker_dir)],
-            timeout=3600,
-        )
+        with tool_docker_build_context(docker_dir) as docker_context:
+            result = subprocess.run(
+                ["docker", "build", "-t", docker_image, str(docker_context)],
+                timeout=3600,
+            )
         if result.returncode != 0:
             console.print(f"[red]Build failed for {docker_image}[/red]")
             raise typer.Exit(code=1)
@@ -789,29 +832,7 @@ def tool_pull(
     import tempfile, json
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
-        # Minimal input — just enough to trigger model loading
-        test_input = {"sequence": "MKWV"}  # tiny sequence
-        if "diffdock" in tool_name:
-            test_input = {"protein_pdb": "ATOM      1  CA  ALA A   1       0.0   0.0   0.0  1.00  0.00\nEND",
-                          "ligand_smiles": "C", "num_poses": 1}
-        elif "proteinmpnn" in tool_name:
-            test_input = {"backbone_pdb": "ATOM      1  N   ALA A   1       0.0   0.0   0.0  1.00  0.00\nATOM      2  CA  ALA A   1       1.5   0.0   0.0  1.00  0.00\nATOM      3  C   ALA A   1       2.5   1.2   0.0  1.00  0.00\nATOM      4  O   ALA A   1       2.2   2.4   0.0  1.00  0.00\nEND",
-                          "num_sequences": 1}
-        elif "rfdiffusion" in tool_name:
-            test_input = {"target_pdb": "ATOM      1  CA  ALA A   1       0.0   0.0   0.0  1.00  0.00\nEND",
-                          "num_designs": 1}
-        elif "evo2" in tool_name and "protein" in tool_name:
-            test_input = {"target_function": "test"}
-        elif "evo2" in tool_name:
-            test_input = {"dna_sequence": "ATG"}
-        elif "genmol" in tool_name:
-            test_input = {"scaffold_smiles": "C", "num_molecules": 1}
-        elif "molmim" in tool_name:
-            test_input = {"input_smiles": "C", "num_variants": 1}
-        elif "msa" in tool_name:
-            test_input = {"sequence": "MKWV"}
-        elif "multimer" in tool_name:
-            test_input = {"sequences": ["MK", "WV"]}
+        test_input = _tool_pull_test_input(tool_name)
 
         (tmpdir / "input.json").write_text(json.dumps(test_input))
 
@@ -942,6 +963,12 @@ def _run_step_command(label: str, cmd: list[str], env: Optional[dict] = None) ->
         return True
     console.print(f"[red]FAIL[/red] {label} (exit={proc.returncode})")
     return False
+
+
+def _pytest_cmd(*args: str) -> list[str]:
+    """Run pytest through the active interpreter for consistent dev environments."""
+
+    return [sys.executable, "-m", "pytest", *args]
 
 
 @trace_app.command("diagnose")
@@ -1158,7 +1185,12 @@ def release_check_cmd(
     if run_tests:
         ok = _run_step_command(
             "Local test suite",
-            ["pytest", "-q", "tests", "-m", "not api_smoke and not e2e and not e2e_matrix"],
+            _pytest_cmd(
+                "-q",
+                "tests",
+                "-m",
+                "not api_smoke and not e2e and not e2e_matrix",
+            ),
         )
         failed = failed or (not ok)
 
@@ -1203,7 +1235,7 @@ def release_check_cmd(
         smoke_env.setdefault("CT_API_SMOKE_STRICT", "1")
         smoke_ok = _run_step_command(
             "Live API smoke checks",
-            ["pytest", "-q", "tests/test_api_smoke.py"],
+            _pytest_cmd("-q", "tests/test_api_smoke.py"),
             env=smoke_env,
         )
         failed = failed or (not smoke_ok)
@@ -1215,7 +1247,7 @@ def release_check_cmd(
         matrix_env["CT_E2E_MATRIX_MAX_FAILED_QUERIES"] = str(max(0, matrix_max_failed))
         matrix_ok = _run_step_command(
             "Live E2E prompt matrix",
-            ["pytest", "-q", "tests/test_e2e_matrix.py", "--run-e2e"],
+            _pytest_cmd("-q", "tests/test_e2e_matrix.py", "--run-e2e"),
             env=matrix_env,
         )
         failed = failed or (not matrix_ok)

--- a/src/ct/cloud/local_runner.py
+++ b/src/ct/cloud/local_runner.py
@@ -7,9 +7,12 @@ For users who have their own NVIDIA GPUs and want to run tools locally.
 import json
 import logging
 import os
-import subprocess
-import uuid
+from contextlib import contextmanager
 from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import uuid
 from typing import Optional
 
 from ct.cloud.structure_inputs import inline_structure_file_args
@@ -17,6 +20,31 @@ from ct.cloud.structure_inputs import inline_structure_file_args
 logger = logging.getLogger("ct.cloud.local_runner")
 
 DEFAULT_WORKSPACE = Path.home() / ".ct" / "gpu-workspace"
+
+
+@contextmanager
+def tool_docker_build_context(build_dir: Path):
+    """Stage a per-tool Docker build context with shared support files."""
+
+    with tempfile.TemporaryDirectory(prefix=f"ct-docker-build-{build_dir.name}-") as tmpdir:
+        staged_dir = Path(tmpdir) / build_dir.name
+        shutil.copytree(build_dir, staged_dir)
+
+        shared_dir = build_dir.parent
+
+        entrypoint = staged_dir / "tool_entrypoint.py"
+        if not entrypoint.exists():
+            shared_entrypoint = shared_dir / "tool_entrypoint.py"
+            if shared_entrypoint.exists():
+                shutil.copy2(shared_entrypoint, entrypoint)
+
+        shared_schema = shared_dir / "_schema_contract.py"
+        if shared_schema.exists():
+            schema_target = staged_dir / "ct" / "tools" / "_schema_contract.py"
+            schema_target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(shared_schema, schema_target)
+
+        yield staged_dir
 
 
 class LocalRunner:
@@ -48,18 +76,11 @@ class LocalRunner:
             logger.info("Building image %s from %s...", image, build_dir)
             print(f"  Building {image} (first run — this may take a few minutes)...")
 
-            # Copy tool_entrypoint.py if missing
-            entrypoint = build_dir / "tool_entrypoint.py"
-            if not entrypoint.exists():
-                shared = build_dir.parent / "tool_entrypoint.py"
-                if shared.exists():
-                    import shutil
-                    shutil.copy2(shared, entrypoint)
-
-            build_result = subprocess.run(
-                ["docker", "build", "-t", image, str(build_dir)],
-                timeout=3600,
-            )
+            with tool_docker_build_context(build_dir) as docker_context:
+                build_result = subprocess.run(
+                    ["docker", "build", "-t", image, str(docker_context)],
+                    timeout=3600,
+                )
             if build_result.returncode != 0:
                 raise RuntimeError(f"Failed to build {image}")
         else:
@@ -106,6 +127,45 @@ class LocalRunner:
     # Weight mounts are handled by _get_cache_mounts() which mounts
     # the host cache directories. No per-model mount logic needed.
 
+    def _resolve_cache_dir(self, env_var: str, default_path: Path) -> Path | None:
+        """Resolve a writable host cache directory for container mounts."""
+
+        requested = Path(os.environ.get(env_var, default_path))
+        try:
+            requested.mkdir(parents=True, exist_ok=True)
+            return requested
+        except OSError as exc:
+            fallback_roots = []
+            configured_root = os.environ.get("CT_LOCAL_CACHE_ROOT")
+            if configured_root:
+                fallback_roots.append(Path(configured_root))
+            fallback_roots.append(self.workspace / ".cache")
+            fallback_roots.append(Path(tempfile.gettempdir()) / "ct-cache")
+
+            for fallback_root in fallback_roots:
+                fallback = fallback_root / requested.name
+                try:
+                    fallback.mkdir(parents=True, exist_ok=True)
+                except OSError:
+                    continue
+
+                logger.warning(
+                    "Falling back to writable cache dir %s for %s (requested %s): %s",
+                    fallback,
+                    env_var,
+                    requested,
+                    exc,
+                )
+                return fallback
+
+            logger.warning(
+                "Skipping cache mount %s after fallback failure for %s: %s",
+                env_var,
+                requested,
+                exc,
+            )
+            return None
+
     def _get_cache_mounts(self) -> list[str]:
         """Mount host model caches into the container.
 
@@ -135,9 +195,9 @@ class LocalRunner:
         }
 
         for env_var, (host_path, container_path) in cache_mappings.items():
-            resolved = Path(os.environ.get(env_var, host_path))
-            resolved.mkdir(parents=True, exist_ok=True)
-            mounts.extend(["-v", f"{resolved}:{container_path}"])
+            resolved = self._resolve_cache_dir(env_var, host_path)
+            if resolved is not None:
+                mounts.extend(["-v", f"{resolved}:{container_path}"])
 
         # ColabFold databases for MSA search (read-only mount, don't create if missing)
         colabfold_db = Path(os.environ.get("COLABFOLD_DB", home / ".cache" / "colabfold_db"))

--- a/src/ct/tools/immunebuilder/Dockerfile
+++ b/src/ct/tools/immunebuilder/Dockerfile
@@ -1,0 +1,43 @@
+# ImmuneBuilder — antibody, nanobody, and TCR structure prediction
+# Source: https://github.com/oxpig/ImmuneBuilder
+
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    git \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -P /tmp \
+    "https://github.com/conda-forge/miniforge/releases/download/24.11.3-0/Miniforge3-Linux-x86_64.sh" \
+    && bash /tmp/Miniforge3-Linux-x86_64.sh -b -p /opt/conda \
+    && rm /tmp/Miniforge3-Linux-x86_64.sh
+
+ENV PATH=/opt/conda/bin:$PATH
+
+RUN mamba install -y -n base \
+    -c pytorch \
+    -c nvidia \
+    -c conda-forge \
+    -c bioconda \
+    python=3.11 \
+    pytorch \
+    pytorch-cuda=12.1 \
+    openmm \
+    pdbfixer \
+    anarci \
+    libstdcxx-ng \
+    pip \
+    && mamba clean --all -y
+
+RUN pip install --no-cache-dir \
+    ImmuneBuilder \
+    "pydantic>=2,<3"
+
+COPY ct/tools/_schema_contract.py /opt/ct/tools/_schema_contract.py
+COPY tool_entrypoint.py /opt/tool_entrypoint.py
+COPY implementation.py /opt/implementation.py
+RUN mkdir -p /workspace
+WORKDIR /workspace
+ENTRYPOINT ["python", "/opt/tool_entrypoint.py"]

--- a/src/ct/tools/immunebuilder/implementation.py
+++ b/src/ct/tools/immunebuilder/implementation.py
@@ -1,0 +1,291 @@
+"""ImmuneBuilder structure prediction for antibodies, nanobodies, and TCRs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import tempfile
+import time
+import traceback
+from typing import Any, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+
+try:
+    from ct.tools._schema_contract import (
+        ToolInputModel,
+        ToolOutputModel,
+        export_tool_contract,
+        structured_error,
+    )
+except ModuleNotFoundError:
+    class ToolInputModel(BaseModel):
+        model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    class ToolOutputModel(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+    def export_tool_contract(
+        input_model: type[BaseModel],
+        output_model: type[BaseModel],
+    ) -> dict[str, Any]:
+        return {
+            "input_schema": input_model.model_json_schema(),
+            "output_schema": output_model.model_json_schema(),
+        }
+
+    def structured_error(summary: str, error: str, **extra: Any) -> dict[str, Any]:
+        payload: dict[str, Any] = {"summary": summary, "error": error, "isError": True}
+        payload.update(extra)
+        return payload
+
+
+AA_SEQUENCE_PATTERN = re.compile(r"^[ARNDCQEGHILKMFPSTWYVBZXOU]+$")
+
+
+def _clean_sequence(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.startswith(">"):
+        raise ValueError(
+            f"`{field_name}` does not accept FASTA input. "
+            "Use the named chain fields with raw sequence text."
+        )
+
+    clean = "".join(text.split()).upper()
+    if not clean:
+        return None
+    if not AA_SEQUENCE_PATTERN.fullmatch(clean):
+        raise ValueError(f"`{field_name}` must contain only valid amino acid symbols.")
+    return clean
+
+
+class ToolInput(ToolInputModel):
+    mode: Literal["antibody", "nanobody", "tcr"] = Field(
+        ...,
+        description="ImmuneBuilder prediction mode.",
+    )
+    heavy_chain: str | None = Field(
+        None,
+        description="Heavy-chain amino acid sequence. Required for `antibody` and `nanobody`.",
+    )
+    light_chain: str | None = Field(
+        None,
+        description="Light-chain amino acid sequence. Required for `antibody` only.",
+    )
+    alpha_chain: str | None = Field(
+        None,
+        description="TCR alpha-chain amino acid sequence. Required for `tcr` only.",
+    )
+    beta_chain: str | None = Field(
+        None,
+        description="TCR beta-chain amino acid sequence. Required for `tcr` only.",
+    )
+    session_id: str = Field(
+        "",
+        description="Optional workspace session identifier used to persist output artifacts.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_payload(cls, payload: Any) -> Any:
+        if not isinstance(payload, dict):
+            raise ValueError("ImmuneBuilder inputs must be provided as an object.")
+
+        if "chains" in payload:
+            raise ValueError(
+                "ImmuneBuilder v1 does not accept `chains`. Use named chain fields instead."
+            )
+        if "sequence" in payload or "sequences" in payload or "fasta" in payload:
+            raise ValueError(
+                "ImmuneBuilder v1 does not accept generic sequence or FASTA inputs. "
+                "Use named chain fields instead."
+            )
+
+        normalized = dict(payload)
+        normalized["mode"] = str(normalized.get("mode", "")).strip().lower()
+        normalized["session_id"] = str(normalized.get("session_id", "")).strip()
+        return normalized
+
+    @field_validator("heavy_chain", "light_chain", "alpha_chain", "beta_chain", mode="before")
+    @classmethod
+    def validate_chain(cls, value: Any, info: ValidationInfo) -> str | None:
+        return _clean_sequence(value, info.field_name)
+
+    @model_validator(mode="after")
+    def validate_mode_fields(self) -> "ToolInput":
+        if self.mode == "antibody":
+            if not self.heavy_chain or not self.light_chain:
+                raise ValueError("`antibody` mode requires both `heavy_chain` and `light_chain`.")
+            if self.alpha_chain or self.beta_chain:
+                raise ValueError("`antibody` mode does not accept `alpha_chain` or `beta_chain`.")
+        elif self.mode == "nanobody":
+            if not self.heavy_chain:
+                raise ValueError("`nanobody` mode requires `heavy_chain`.")
+            if self.light_chain or self.alpha_chain or self.beta_chain:
+                raise ValueError("`nanobody` mode accepts only `heavy_chain`.")
+        elif self.mode == "tcr":
+            if not self.alpha_chain or not self.beta_chain:
+                raise ValueError("`tcr` mode requires both `alpha_chain` and `beta_chain`.")
+            if self.heavy_chain or self.light_chain:
+                raise ValueError("`tcr` mode does not accept `heavy_chain` or `light_chain`.")
+        return self
+
+
+class ToolOutput(ToolOutputModel):
+    summary: str = Field(..., description="Human-readable summary of the ImmuneBuilder run.")
+    pdb_content: str = Field(..., description="Predicted structure in PDB format.")
+    mode: Literal["antibody", "nanobody", "tcr"] = Field(..., description="Prediction mode used.")
+    chain_labels: list[str] = Field(
+        ...,
+        description="ImmuneBuilder chain labels included in the prediction.",
+    )
+    num_chains: int = Field(..., description="Number of chains passed to the predictor.")
+    metrics: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional runtime metadata for the prediction.",
+    )
+
+
+ToolInput.model_rebuild()
+ToolOutput.model_rebuild()
+
+
+def normalize_args(args: dict[str, Any]) -> dict[str, Any]:
+    try:
+        model = ToolInput.model_validate(dict(args))
+    except ValidationError as exc:
+        raise ValueError(str(exc.errors()[0]["msg"])) from exc
+    return model.model_dump(exclude_none=True)
+
+
+def get_contract() -> dict[str, Any]:
+    """Expose structured input/output schemas for tests and UI scaffolding."""
+
+    return export_tool_contract(ToolInput, ToolOutput)
+
+
+def _build_predictor_request(
+    normalized: dict[str, Any],
+) -> tuple[type[Any], dict[str, str], list[str]]:
+    from ImmuneBuilder import ABodyBuilder2, NanoBodyBuilder2, TCRBuilder2
+
+    mode = normalized["mode"]
+    if mode == "antibody":
+        return (
+            ABodyBuilder2,
+            {"H": normalized["heavy_chain"], "L": normalized["light_chain"]},
+            ["H", "L"],
+        )
+    if mode == "nanobody":
+        return (
+            NanoBodyBuilder2,
+            {"H": normalized["heavy_chain"]},
+            ["H"],
+        )
+    return (
+        TCRBuilder2,
+        {"A": normalized["alpha_chain"], "B": normalized["beta_chain"]},
+        ["A", "B"],
+    )
+
+
+def run(
+    mode: str = "",
+    heavy_chain: str = "",
+    light_chain: str = "",
+    alpha_chain: str = "",
+    beta_chain: str = "",
+    session_id: str = "",
+    **kwargs,
+) -> dict[str, Any]:
+    try:
+        normalized = normalize_args(
+            {
+                "mode": mode,
+                "heavy_chain": heavy_chain,
+                "light_chain": light_chain,
+                "alpha_chain": alpha_chain,
+                "beta_chain": beta_chain,
+                "session_id": session_id,
+                **kwargs,
+            }
+        )
+    except ValueError as exc:
+        return structured_error(
+            summary=f"Error: {exc}",
+            error="invalid_immunebuilder_input",
+            detail=str(exc),
+        )
+
+    try:
+        predictor_cls, sequences, chain_labels = _build_predictor_request(normalized)
+    except Exception:
+        return structured_error(
+            summary="Error: ImmuneBuilder dependencies are not installed in this runtime.",
+            error="immunebuilder_not_installed",
+            detail=traceback.format_exc(),
+        )
+
+    t0 = time.time()
+
+    try:
+        predictor = predictor_cls()
+        prediction = predictor.predict(sequences)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdb", delete=False) as tmp:
+            output_path = Path(tmp.name)
+
+        try:
+            prediction.save(str(output_path))
+            pdb_content = output_path.read_text(encoding="utf-8")
+        finally:
+            if output_path.exists():
+                output_path.unlink()
+
+        if not pdb_content.strip():
+            return structured_error(
+                summary="ImmuneBuilder completed but produced an empty PDB output.",
+                error="no_output",
+            )
+
+        session_id = normalized.get("session_id", "")
+        if session_id:
+            workspace_dir = Path(f"/vol/workspace/{session_id}")
+            workspace_dir.mkdir(parents=True, exist_ok=True)
+            (workspace_dir / "predicted_structure.pdb").write_text(pdb_content, encoding="utf-8")
+
+        output = ToolOutput(
+            summary=(
+                f"ImmuneBuilder predicted a {normalized['mode']} structure "
+                f"with {len(chain_labels)} chain(s)."
+            ),
+            pdb_content=pdb_content,
+            mode=normalized["mode"],
+            chain_labels=chain_labels,
+            num_chains=len(chain_labels),
+            metrics={
+                "predictor": predictor_cls.__name__,
+                "num_residues": sum(len(sequence) for sequence in sequences.values()),
+                "time_total_s": round(time.time() - t0, 2),
+            },
+        )
+        return output.model_dump()
+    except Exception as exc:
+        return structured_error(
+            summary=f"Error: ImmuneBuilder failed: {exc}",
+            error="immunebuilder_runtime_error",
+            detail=traceback.format_exc(),
+        )

--- a/src/ct/tools/immunebuilder/tool.yaml
+++ b/src/ct/tools/immunebuilder/tool.yaml
@@ -1,0 +1,61 @@
+name: structure.immunebuilder
+display_name: ImmuneBuilder
+description: Predict antibody, nanobody, and T-cell receptor structures from named chain sequences using ImmuneBuilder (GPU).
+category: structure
+usage_guide: Use for fast immune-protein structure prediction when you have antibody, nanobody, or TCR chain sequences and want a reviewable named-chain contract.
+docker_image: celltype/immunebuilder:latest
+reference:
+  repo_url: https://github.com/oxpig/ImmuneBuilder
+  package_url: https://pypi.org/project/ImmuneBuilder/
+examples:
+  - id: antibody-basic
+    title: Antibody variable domain
+    description: Predict a paired heavy/light-chain antibody structure.
+    args:
+      mode: antibody
+      heavy_chain: EVQLVESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAIYSGGSTYYADSVKGRFTISRDNSKNTLYLQMNSLRAEDTAVYYCAR
+      light_chain: DIQMTQSPSSLSASVGDRVTITCRASQSISSYLNWYQQKPGKAPKLLIYDASSLESGVPSRFSGSGSGTDFTLTISSLQPEDFATYYCQQYNSYPYTFGQGTKVEIK
+  - id: nanobody-basic
+    title: Nanobody heavy chain
+    description: Predict a single-chain nanobody structure.
+    args:
+      mode: nanobody
+      heavy_chain: QVQLVESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAIYSGGSTYYADSVKGRFTISRDNSKNTLYLQMNSLRAEDTAVYYCAR
+  - id: tcr-basic
+    title: T-cell receptor alpha/beta chains
+    description: Predict a paired TCR structure.
+    args:
+      mode: tcr
+      alpha_chain: MNHVTQTPKFQVLKTGQSMTLQCAQDMNHNSMYWYRQDPGQGLRLIYYSAAADITDKGEVPNGYNVSRLKKQNFLLGLESAAPSQTSVYFCASSLGQGAEAFFGQGTRLTVV
+      beta_chain: DTGITQSPKYLFRKEGQNVTLSCEQNLNHDAMYWYRQDPGQGLRLIHYSVGAGTTDQGEVPNGYNVSRSTTEDFPLRLLSAAPSQTSVYFCASSPGLAGNEKLFFGSGTQLSVL
+parameters:
+  type: object
+  additionalProperties: false
+  required:
+    - mode
+  properties:
+    mode:
+      type: string
+      description: Prediction mode controlling which chain fields are required.
+      enum: [antibody, nanobody, tcr]
+    heavy_chain:
+      type: string
+      description: Heavy-chain amino acid sequence. Required for antibody and nanobody modes.
+    light_chain:
+      type: string
+      description: Light-chain amino acid sequence. Required for antibody mode only.
+    alpha_chain:
+      type: string
+      description: TCR alpha-chain amino acid sequence. Required for tcr mode only.
+    beta_chain:
+      type: string
+      description: TCR beta-chain amino acid sequence. Required for tcr mode only.
+compute:
+  requires_gpu: true
+  min_vram_gb: 24
+  gpu_profile: structure
+  estimated_cost_usd: 0.08
+  gpu_type: A10G
+modal_function: predict_structure_immunebuilder
+execution:
+  timeout_s: 900

--- a/src/ct/tools/immunebuilder/tool_entrypoint.py
+++ b/src/ct/tools/immunebuilder/tool_entrypoint.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Standard container entrypoint for all GPU/CPU tools.
+Reads input.json, calls implementation.run(**args), writes output.json."""
+import json, os, sys, traceback
+
+def main():
+    input_file = os.environ.get("INPUT_FILE", "/workspace/input.json")
+    output_file = os.environ.get("OUTPUT_FILE", "/workspace/output.json")
+    try:
+        with open(input_file) as f:
+            args = json.load(f)
+        if not isinstance(args, dict):
+            args = {}
+        sys.path.insert(0, "/opt")
+        from implementation import run
+        result = run(**args)
+        if not isinstance(result, dict):
+            result = {"summary": str(result)}
+        with open(output_file, "w") as f:
+            json.dump(result, f, indent=2, default=str)
+    except Exception as e:
+        with open(output_file, "w") as f:
+            json.dump({"summary": f"Error: {e}", "error": traceback.format_exc()}, f, indent=2)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from ct.agent.config import Config
+from ct.agent.trace import TraceLogger
 from ct.cli import app
 
 
@@ -179,6 +180,17 @@ def test_knowledge_ingest_error_exits_nonzero():
     assert "boom" in result.stdout
 
 
+def test_tool_pull_uses_named_chain_warmup_for_immunebuilder():
+    from ct.cli import _tool_pull_test_input
+
+    test_input = _tool_pull_test_input("structure.immunebuilder")
+
+    assert test_input["mode"] == "nanobody"
+    assert "heavy_chain" in test_input
+    assert "sequence" not in test_input
+    assert "fasta" not in test_input
+
+
 def test_knowledge_benchmark_strict_failure_exits_nonzero():
     class FakeSuite:
         def run(self):
@@ -230,6 +242,25 @@ def test_trace_diagnose_strict_exits_on_unclosed_query(tmp_path):
 
     result = runner.invoke(app, ["trace", "diagnose", "--path", str(path), "--strict"])
     assert result.exit_code == 2
+
+
+def test_trace_diagnostics_treat_text_only_query_as_activity():
+    trace = TraceLogger("cli-trace-text-only")
+    trace.query_start("answer directly")
+    trace.events.append(
+        {
+            "type": "text",
+            "content": "Here is the answer.",
+            "timestamp": 123.0,
+        }
+    )
+    trace.query_end(iterations=1, total_steps=0, completed_steps=0, failed_steps=0)
+
+    diag = trace.diagnostics()
+
+    assert diag["queries_with_no_plan"] == []
+    assert diag["queries_with_no_completion"] == []
+    assert diag["queries"][0]["activity_count"] == 1
 
 
 def test_trace_export_creates_bundle(tmp_path):
@@ -371,6 +402,51 @@ def test_release_check_fails_on_trace_integrity_issues(tmp_path):
 
     assert result.exit_code == 2
     assert "Trace diagnostics detected integrity issues" in result.stdout
+
+
+def test_release_check_accepts_text_only_trace(tmp_path):
+    cfg = Config(data={"llm.api_key": "x"})
+
+    class FakeSuite:
+        def run(self):
+            return {
+                "total_cases": 2,
+                "expected_behavior_matches": 2,
+                "pass_rate": 1.0,
+            }
+
+        def gate(self, summary, min_pass_rate=0.9):
+            del summary, min_pass_rate
+            return {
+                "ok": True,
+                "message": "passed",
+            }
+
+    trace = TraceLogger("text-only-trace")
+    trace.query_start("answer directly")
+    trace.events.append(
+        {
+            "type": "text",
+            "content": "Healthy text-only response.",
+            "timestamp": 123.0,
+        }
+    )
+    trace.query_end(iterations=1, total_steps=0, completed_steps=0, failed_steps=0)
+    trace_path = tmp_path / "text-only-trace.trace.jsonl"
+    trace.save(trace_path)
+
+    with patch("ct.agent.config.Config.load", return_value=cfg), patch(
+        "ct.agent.doctor.run_checks", return_value=[]
+    ), patch("ct.agent.doctor.has_errors", return_value=False), patch(
+        "ct.agent.doctor.to_table", return_value="doctor ok"
+    ), patch("ct.kb.benchmarks.BenchmarkSuite.load", return_value=FakeSuite()):
+        result = runner.invoke(
+            app,
+            ["release-check", "--no-tests", "--trace-path", str(trace_path)],
+        )
+
+    assert result.exit_code == 0
+    assert "Release check passed" in result.stdout
 
 
 def test_release_check_pharma_policy_fails_without_profile():

--- a/tests/test_gpu_registry.py
+++ b/tests/test_gpu_registry.py
@@ -1,5 +1,7 @@
 """Tests for tool registry GPU metadata support."""
 
+from pathlib import Path
+
 import pytest
 
 
@@ -211,3 +213,25 @@ class TestGPUToolsLoaded:
 
         diffdock = registry.get_tool("structure.diffdock")
         assert diffdock.min_vram_gb == 32
+
+    def test_immunebuilder_registers_gpu_metadata(self):
+        tool_yaml = Path(__file__).resolve().parents[1] / "src/ct/tools/immunebuilder/tool.yaml"
+        if not tool_yaml.exists():
+            pytest.skip("ImmuneBuilder tool directory is not present in this workspace yet.")
+
+        from ct.tools import ensure_loaded, registry
+        from ct.tools._container_tools import load_container_tools
+
+        ensure_loaded()
+
+        tool = registry.get_tool("structure.immunebuilder")
+        if tool is None:
+            load_container_tools()
+            tool = registry.get_tool("structure.immunebuilder")
+
+        assert tool is not None
+        assert tool.category == "structure"
+        assert tool.requires_gpu is True
+        assert tool.gpu_profile == "structure"
+        assert tool.docker_image
+        assert tool.min_vram_gb == 24

--- a/tests/test_immunebuilder.py
+++ b/tests/test_immunebuilder.py
@@ -1,4 +1,4 @@
-"""Contract tests for the ImmuneBuilder container-tool implementation."""
+"""Behavioral tests for the ImmuneBuilder container-tool implementation."""
 
 from __future__ import annotations
 
@@ -30,6 +30,20 @@ VALID_BETA_CHAIN = (
     "DTGITQSPKYLFRKEGQNVTLSCEQNLNHDAMYWYRQDPGQGLRLIHYSVGAGTTDQGEVPNGYNVSRSTTEDFPLRLLS"
     "AAPSQTSVYFCASSPGLAGNEKLFFGSGTQLSVL"
 )
+MOCK_PDB = (
+    "HEADER MOCK\n"
+    "ATOM      1  CA  ALA H   1       0.0   0.0   0.0  1.00 70.00           C\n"
+    "END\n"
+)
+
+
+def _messy_sequence(sequence: str) -> str:
+    midpoint = len(sequence) // 2
+    return f"  {sequence[:midpoint].lower()} \n {sequence[midpoint:]}  "
+
+
+def _error_blob(result: dict[str, object]) -> str:
+    return f"{result.get('summary', '')} {result.get('detail', '')}".lower()
 
 
 def _load_immunebuilder_module(*, block_shared_helper: bool = False):
@@ -62,6 +76,52 @@ def _load_immunebuilder_module(*, block_shared_helper: bool = False):
         builtins.__import__ = original_import
 
     return module
+
+
+def _make_fake_immunebuilder_module(
+    *,
+    pdb_text: str = MOCK_PDB,
+    save_side_effect: Exception | None = None,
+):
+    class FakePrediction:
+        saved_paths: list[str] = []
+
+        def save(self, path: str):
+            type(self).saved_paths.append(path)
+            if save_side_effect is not None:
+                raise save_side_effect
+            Path(path).write_text(pdb_text, encoding="utf-8")
+
+    def _builder_class(name: str):
+        class FakeBuilder:
+            last_sequences: dict[str, str] | None = None
+
+            def predict(self, sequences):
+                type(self).last_sequences = dict(sequences)
+                return FakePrediction()
+
+        FakeBuilder.__name__ = name
+        return FakeBuilder
+
+    builders = {
+        "ABodyBuilder2": _builder_class("FakeABodyBuilder2"),
+        "NanoBodyBuilder2": _builder_class("FakeNanoBodyBuilder2"),
+        "TCRBuilder2": _builder_class("FakeTCRBuilder2"),
+    }
+    return types.SimpleNamespace(**builders), builders, FakePrediction
+
+
+def _redirect_workspace_paths(tmp_path: Path):
+    real_path = Path
+
+    def fake_path(value):
+        raw = str(value)
+        if raw.startswith("/vol/workspace/"):
+            relative = raw.removeprefix("/vol/workspace/").lstrip("/")
+            return tmp_path / "vol" / "workspace" / relative
+        return real_path(value)
+
+    return fake_path
 
 
 @pytest.fixture(scope="module")
@@ -101,6 +161,7 @@ class TestImmuneBuilderContract:
             "light_chain",
             "alpha_chain",
             "beta_chain",
+            "session_id",
         } <= set(input_properties)
         assert "chains" not in input_properties
         assert "sequence" not in input_properties
@@ -109,21 +170,16 @@ class TestImmuneBuilderContract:
 
         assert output_schema["type"] == "object"
         output_properties = output_schema["properties"]
-        required_output_fields = {"summary", "pdb_content", "mode", "chain_labels", "num_chains"}
+        required_output_fields = {
+            "summary",
+            "pdb_content",
+            "mode",
+            "chain_labels",
+            "num_chains",
+        }
         assert required_output_fields <= set(output_properties)
         assert required_output_fields <= set(output_schema.get("required", []))
-
-    def test_run_rejects_generic_chain_map_passthrough(self, immunebuilder_module):
-        result = immunebuilder_module.run(
-            mode="nanobody",
-            heavy_chain=VALID_HEAVY_CHAIN,
-            chains={"H": VALID_HEAVY_CHAIN},
-        )
-
-        assert isinstance(result, dict)
-        assert result.get("error")
-        assert result.get("isError") is True
-        assert "chains" in f"{result.get('summary', '')} {result.get('detail', '')}".lower()
+        assert "metrics" in output_properties
 
     def test_fallback_contract_stays_strict_without_shared_helper(self):
         immunebuilder_module = _load_immunebuilder_module(block_shared_helper=True)
@@ -137,33 +193,78 @@ class TestImmuneBuilderContract:
             unexpected_field="typo",
         )
 
-        assert isinstance(result, dict)
         assert result.get("error") == "invalid_immunebuilder_input"
         assert result.get("isError") is True
-        detail_blob = f"{result.get('summary', '')} {result.get('detail', '')}".lower()
+        detail_blob = _error_blob(result)
         assert "extra" in detail_blob or "permit" in detail_blob or "unexpected_field" in detail_blob
 
-    def test_run_rejects_antibody_without_light_chain(self, immunebuilder_module):
+
+class TestImmuneBuilderInputValidation:
+    def test_normalize_args_canonicalizes_mode_sequences_and_session_id(
+        self,
+        immunebuilder_module,
+    ):
+        normalized = immunebuilder_module.normalize_args(
+            {
+                "mode": "  ANTIBODY ",
+                "heavy_chain": _messy_sequence(VALID_HEAVY_CHAIN),
+                "light_chain": _messy_sequence(VALID_LIGHT_CHAIN),
+                "session_id": "  run-123  ",
+            }
+        )
+
+        assert normalized == {
+            "mode": "antibody",
+            "heavy_chain": VALID_HEAVY_CHAIN,
+            "light_chain": VALID_LIGHT_CHAIN,
+            "session_id": "run-123",
+        }
+
+    @pytest.mark.parametrize(
+        ("extra_field", "extra_value", "expected_text"),
+        [
+            ("chains", {"H": VALID_HEAVY_CHAIN}, "chains"),
+            ("sequence", VALID_HEAVY_CHAIN, "generic sequence"),
+            ("sequences", [VALID_HEAVY_CHAIN], "generic sequence"),
+            ("fasta", f">heavy\n{VALID_HEAVY_CHAIN}", "fasta"),
+        ],
+    )
+    def test_run_rejects_legacy_sequence_inputs(
+        self,
+        immunebuilder_module,
+        extra_field,
+        extra_value,
+        expected_text,
+    ):
         result = immunebuilder_module.run(
-            mode="antibody",
+            mode="nanobody",
             heavy_chain=VALID_HEAVY_CHAIN,
+            **{extra_field: extra_value},
         )
 
-        assert isinstance(result, dict)
-        assert result.get("error")
+        assert result.get("error") == "invalid_immunebuilder_input"
         assert result.get("isError") is True
-        assert "light_chain" in f"{result.get('summary', '')} {result.get('detail', '')}"
+        assert expected_text in _error_blob(result)
 
-    def test_run_rejects_tcr_without_beta_chain(self, immunebuilder_module):
-        result = immunebuilder_module.run(
-            mode="tcr",
-            alpha_chain=VALID_ALPHA_CHAIN,
-        )
+    @pytest.mark.parametrize(
+        ("payload", "expected_text"),
+        [
+            ({"mode": "antibody", "heavy_chain": VALID_HEAVY_CHAIN}, "light_chain"),
+            ({"mode": "nanobody"}, "heavy_chain"),
+            ({"mode": "tcr", "alpha_chain": VALID_ALPHA_CHAIN}, "beta_chain"),
+        ],
+    )
+    def test_run_rejects_missing_mode_specific_chains(
+        self,
+        immunebuilder_module,
+        payload,
+        expected_text,
+    ):
+        result = immunebuilder_module.run(**payload)
 
-        assert isinstance(result, dict)
-        assert result.get("error")
+        assert result.get("error") == "invalid_immunebuilder_input"
         assert result.get("isError") is True
-        assert "beta_chain" in f"{result.get('summary', '')} {result.get('detail', '')}"
+        assert expected_text in _error_blob(result)
 
     def test_run_rejects_mixed_chain_families(self, immunebuilder_module):
         result = immunebuilder_module.run(
@@ -174,48 +275,233 @@ class TestImmuneBuilderContract:
             beta_chain=VALID_BETA_CHAIN,
         )
 
-        assert isinstance(result, dict)
-        assert result.get("error")
+        assert result.get("error") == "invalid_immunebuilder_input"
         assert result.get("isError") is True
-        detail_blob = f"{result.get('summary', '')} {result.get('detail', '')}".lower()
+        detail_blob = _error_blob(result)
         assert "alpha_chain" in detail_blob or "beta_chain" in detail_blob or "tcr" in detail_blob
 
-    def test_run_predicts_antibody_with_mocked_immunebuilder(
+    @pytest.mark.parametrize(
+        ("payload", "expected_text"),
+        [
+            (
+                {
+                    "mode": "nanobody",
+                    "heavy_chain": f">heavy\n{VALID_HEAVY_CHAIN}",
+                },
+                "fasta",
+            ),
+            (
+                {
+                    "mode": "antibody",
+                    "heavy_chain": VALID_HEAVY_CHAIN,
+                    "light_chain": f"{VALID_LIGHT_CHAIN}*",
+                },
+                "valid amino acid",
+            ),
+        ],
+    )
+    def test_run_rejects_invalid_chain_text(
+        self,
+        immunebuilder_module,
+        payload,
+        expected_text,
+    ):
+        result = immunebuilder_module.run(**payload)
+
+        assert result.get("error") == "invalid_immunebuilder_input"
+        assert result.get("isError") is True
+        assert expected_text in _error_blob(result)
+
+
+class TestImmuneBuilderExecution:
+    @pytest.mark.parametrize(
+        ("mode", "raw_kwargs", "expected_builder", "expected_sequences", "expected_labels"),
+        [
+            (
+                "antibody",
+                {
+                    "heavy_chain": _messy_sequence(VALID_HEAVY_CHAIN),
+                    "light_chain": _messy_sequence(VALID_LIGHT_CHAIN),
+                },
+                "ABodyBuilder2",
+                {"H": VALID_HEAVY_CHAIN, "L": VALID_LIGHT_CHAIN},
+                ["H", "L"],
+            ),
+            (
+                "nanobody",
+                {"heavy_chain": _messy_sequence(VALID_HEAVY_CHAIN)},
+                "NanoBodyBuilder2",
+                {"H": VALID_HEAVY_CHAIN},
+                ["H"],
+            ),
+            (
+                "tcr",
+                {
+                    "alpha_chain": _messy_sequence(VALID_ALPHA_CHAIN),
+                    "beta_chain": _messy_sequence(VALID_BETA_CHAIN),
+                },
+                "TCRBuilder2",
+                {"A": VALID_ALPHA_CHAIN, "B": VALID_BETA_CHAIN},
+                ["A", "B"],
+            ),
+        ],
+    )
+    def test_build_predictor_request_selects_expected_builder(
+        self,
+        immunebuilder_module,
+        monkeypatch,
+        mode,
+        raw_kwargs,
+        expected_builder,
+        expected_sequences,
+        expected_labels,
+    ):
+        fake_module, builders, _ = _make_fake_immunebuilder_module()
+        monkeypatch.setitem(sys.modules, "ImmuneBuilder", fake_module)
+
+        normalized = immunebuilder_module.normalize_args({"mode": mode, **raw_kwargs})
+        predictor_cls, sequences, chain_labels = immunebuilder_module._build_predictor_request(
+            normalized
+        )
+
+        assert predictor_cls is builders[expected_builder]
+        assert sequences == expected_sequences
+        assert chain_labels == expected_labels
+
+    @pytest.mark.parametrize(
+        ("mode", "raw_kwargs", "expected_builder", "expected_sequences", "expected_labels"),
+        [
+            (
+                "antibody",
+                {
+                    "heavy_chain": _messy_sequence(VALID_HEAVY_CHAIN),
+                    "light_chain": _messy_sequence(VALID_LIGHT_CHAIN),
+                },
+                "ABodyBuilder2",
+                {"H": VALID_HEAVY_CHAIN, "L": VALID_LIGHT_CHAIN},
+                ["H", "L"],
+            ),
+            (
+                "nanobody",
+                {"heavy_chain": _messy_sequence(VALID_HEAVY_CHAIN)},
+                "NanoBodyBuilder2",
+                {"H": VALID_HEAVY_CHAIN},
+                ["H"],
+            ),
+            (
+                "tcr",
+                {
+                    "alpha_chain": _messy_sequence(VALID_ALPHA_CHAIN),
+                    "beta_chain": _messy_sequence(VALID_BETA_CHAIN),
+                },
+                "TCRBuilder2",
+                {"A": VALID_ALPHA_CHAIN, "B": VALID_BETA_CHAIN},
+                ["A", "B"],
+            ),
+        ],
+    )
+    def test_run_executes_each_mode_with_normalized_sequences(
+        self,
+        immunebuilder_module,
+        monkeypatch,
+        mode,
+        raw_kwargs,
+        expected_builder,
+        expected_sequences,
+        expected_labels,
+    ):
+        fake_module, builders, fake_prediction = _make_fake_immunebuilder_module()
+        monkeypatch.setitem(sys.modules, "ImmuneBuilder", fake_module)
+
+        result = immunebuilder_module.run(mode=mode, **raw_kwargs)
+
+        assert result["summary"] == (
+            f"ImmuneBuilder predicted a {mode} structure with {len(expected_labels)} chain(s)."
+        )
+        assert result["mode"] == mode
+        assert result["chain_labels"] == expected_labels
+        assert result["num_chains"] == len(expected_labels)
+        assert result["pdb_content"] == MOCK_PDB
+        assert result["metrics"]["predictor"] == builders[expected_builder].__name__
+        assert result["metrics"]["num_residues"] == sum(len(seq) for seq in expected_sequences.values())
+        assert builders[expected_builder].last_sequences == expected_sequences
+        assert fake_prediction.saved_paths
+        assert not Path(fake_prediction.saved_paths[-1]).exists()
+
+    def test_run_persists_session_artifact(self, immunebuilder_module, monkeypatch, tmp_path):
+        fake_module, _, _ = _make_fake_immunebuilder_module()
+        monkeypatch.setitem(sys.modules, "ImmuneBuilder", fake_module)
+        monkeypatch.setattr(immunebuilder_module, "Path", _redirect_workspace_paths(tmp_path))
+
+        result = immunebuilder_module.run(
+            mode="nanobody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+            session_id="  session-42  ",
+        )
+
+        saved_path = tmp_path / "vol" / "workspace" / "session-42" / "predicted_structure.pdb"
+        assert saved_path.exists()
+        assert saved_path.read_text(encoding="utf-8") == result["pdb_content"]
+
+    def test_run_returns_no_output_when_saved_pdb_is_blank(
         self,
         immunebuilder_module,
         monkeypatch,
     ):
-        class FakePrediction:
-            def save(self, path: str):
-                Path(path).write_text(
-                    "HEADER MOCK\n"
-                    "ATOM      1  CA  ALA H   1       0.0   0.0   0.0  1.00 70.00           C\n"
-                    "END\n"
-                )
+        fake_module, _, fake_prediction = _make_fake_immunebuilder_module(pdb_text=" \n")
+        monkeypatch.setitem(sys.modules, "ImmuneBuilder", fake_module)
 
-        class FakeABodyBuilder2:
-            last_sequences = None
+        result = immunebuilder_module.run(
+            mode="nanobody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+        )
 
-            def predict(self, sequences):
-                type(self).last_sequences = sequences
-                return FakePrediction()
+        assert result.get("error") == "no_output"
+        assert result.get("isError") is True
+        assert fake_prediction.saved_paths
+        assert not Path(fake_prediction.saved_paths[-1]).exists()
 
-        fake_module = types.SimpleNamespace(
-            ABodyBuilder2=FakeABodyBuilder2,
-            NanoBodyBuilder2=type("FakeNanoBodyBuilder2", (), {}),
-            TCRBuilder2=type("FakeTCRBuilder2", (), {}),
+    def test_run_wraps_prediction_save_failure_and_cleans_temp_file(
+        self,
+        immunebuilder_module,
+        monkeypatch,
+    ):
+        fake_module, _, fake_prediction = _make_fake_immunebuilder_module(
+            save_side_effect=RuntimeError("simulated save failure")
         )
         monkeypatch.setitem(sys.modules, "ImmuneBuilder", fake_module)
 
         result = immunebuilder_module.run(
-            mode="antibody",
+            mode="nanobody",
             heavy_chain=VALID_HEAVY_CHAIN,
-            light_chain=VALID_LIGHT_CHAIN,
         )
 
-        assert result["mode"] == "antibody"
-        assert result["chain_labels"] == ["H", "L"]
-        assert result["num_chains"] == 2
-        assert "HEADER MOCK" in result["pdb_content"]
-        assert result["metrics"]["predictor"] == "FakeABodyBuilder2"
-        assert FakeABodyBuilder2.last_sequences == {"H": VALID_HEAVY_CHAIN, "L": VALID_LIGHT_CHAIN}
+        assert result.get("error") == "immunebuilder_runtime_error"
+        assert result.get("isError") is True
+        assert "simulated save failure" in _error_blob(result)
+        assert fake_prediction.saved_paths
+        assert not Path(fake_prediction.saved_paths[-1]).exists()
+
+    def test_run_returns_dependency_error_when_immunebuilder_import_fails(
+        self,
+        immunebuilder_module,
+        monkeypatch,
+    ):
+        original_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "ImmuneBuilder":
+                raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+        monkeypatch.delitem(sys.modules, "ImmuneBuilder", raising=False)
+
+        result = immunebuilder_module.run(
+            mode="nanobody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+        )
+
+        assert result.get("error") == "immunebuilder_not_installed"
+        assert result.get("isError") is True
+        assert "not installed" in _error_blob(result)

--- a/tests/test_immunebuilder.py
+++ b/tests/test_immunebuilder.py
@@ -1,0 +1,221 @@
+"""Contract tests for the ImmuneBuilder container-tool implementation."""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+TOOL_DIR = Path(__file__).resolve().parents[1] / "src/ct/tools/immunebuilder"
+IMPLEMENTATION_PATH = TOOL_DIR / "implementation.py"
+
+VALID_HEAVY_CHAIN = (
+    "EVQLVESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAIYSGGSTYYADSVKGRFTISRDNSKNTLY"
+    "LQMNSLRAEDTAVYYCAR"
+)
+VALID_LIGHT_CHAIN = (
+    "DIQMTQSPSSLSASVGDRVTITCRASQSISSYLNWYQQKPGKAPKLLIYDASSLESGVPSRFSGSGSGTDFTLTISSLQ"
+    "PEDFATYYCQQYNSYPYTFGQGTKVEIK"
+)
+VALID_ALPHA_CHAIN = (
+    "MNHVTQTPKFQVLKTGQSMTLQCAQDMNHNSMYWYRQDPGQGLRLIYYSAAADITDKGEVPNGYNVSRLKKQNFLLGLES"
+    "AAPSQTSVYFCASSLGQGAEAFFGQGTRLTVV"
+)
+VALID_BETA_CHAIN = (
+    "DTGITQSPKYLFRKEGQNVTLSCEQNLNHDAMYWYRQDPGQGLRLIHYSVGAGTTDQGEVPNGYNVSRSTTEDFPLRLLS"
+    "AAPSQTSVYFCASSPGLAGNEKLFFGSGTQLSVL"
+)
+
+
+def _load_immunebuilder_module(*, block_shared_helper: bool = False):
+    if not IMPLEMENTATION_PATH.exists():
+        pytest.skip("ImmuneBuilder implementation is not present in this workspace yet.")
+
+    spec = importlib.util.spec_from_file_location(
+        "ct_test_immunebuilder_implementation",
+        IMPLEMENTATION_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Could not load module from {IMPLEMENTATION_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    if not block_shared_helper:
+        spec.loader.exec_module(module)
+        return module
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ct.tools._schema_contract":
+            raise ModuleNotFoundError(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    try:
+        builtins.__import__ = guarded_import
+        spec.loader.exec_module(module)
+    finally:
+        builtins.__import__ = original_import
+
+    return module
+
+
+@pytest.fixture(scope="module")
+def immunebuilder_module():
+    return _load_immunebuilder_module()
+
+
+class TestImmuneBuilderContract:
+    def test_dockerfile_installs_pydantic(self):
+        dockerfile = TOOL_DIR / "Dockerfile"
+        if not dockerfile.exists():
+            pytest.skip("ImmuneBuilder Dockerfile is not present in this workspace yet.")
+
+        dockerfile_text = dockerfile.read_text(encoding="utf-8").lower()
+        assert "pydantic" in dockerfile_text
+
+    def test_contract_exposes_named_chain_fields(self, immunebuilder_module):
+        assert hasattr(
+            immunebuilder_module,
+            "get_contract",
+        ), "implementation.py must expose get_contract()"
+
+        contract = immunebuilder_module.get_contract()
+        assert isinstance(contract, dict)
+        assert {"input_schema", "output_schema"} <= set(contract)
+
+        input_schema = contract["input_schema"]
+        output_schema = contract["output_schema"]
+
+        assert input_schema["type"] == "object"
+        assert input_schema.get("additionalProperties") is False
+
+        input_properties = input_schema["properties"]
+        assert {
+            "mode",
+            "heavy_chain",
+            "light_chain",
+            "alpha_chain",
+            "beta_chain",
+        } <= set(input_properties)
+        assert "chains" not in input_properties
+        assert "sequence" not in input_properties
+        assert set(input_properties["mode"].get("enum", [])) == {"antibody", "nanobody", "tcr"}
+        assert "mode" in set(input_schema.get("required", []))
+
+        assert output_schema["type"] == "object"
+        output_properties = output_schema["properties"]
+        required_output_fields = {"summary", "pdb_content", "mode", "chain_labels", "num_chains"}
+        assert required_output_fields <= set(output_properties)
+        assert required_output_fields <= set(output_schema.get("required", []))
+
+    def test_run_rejects_generic_chain_map_passthrough(self, immunebuilder_module):
+        result = immunebuilder_module.run(
+            mode="nanobody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+            chains={"H": VALID_HEAVY_CHAIN},
+        )
+
+        assert isinstance(result, dict)
+        assert result.get("error")
+        assert result.get("isError") is True
+        assert "chains" in f"{result.get('summary', '')} {result.get('detail', '')}".lower()
+
+    def test_fallback_contract_stays_strict_without_shared_helper(self):
+        immunebuilder_module = _load_immunebuilder_module(block_shared_helper=True)
+
+        contract = immunebuilder_module.get_contract()
+        assert contract["input_schema"].get("additionalProperties") is False
+
+        result = immunebuilder_module.run(
+            mode="nanobody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+            unexpected_field="typo",
+        )
+
+        assert isinstance(result, dict)
+        assert result.get("error") == "invalid_immunebuilder_input"
+        assert result.get("isError") is True
+        detail_blob = f"{result.get('summary', '')} {result.get('detail', '')}".lower()
+        assert "extra" in detail_blob or "permit" in detail_blob or "unexpected_field" in detail_blob
+
+    def test_run_rejects_antibody_without_light_chain(self, immunebuilder_module):
+        result = immunebuilder_module.run(
+            mode="antibody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+        )
+
+        assert isinstance(result, dict)
+        assert result.get("error")
+        assert result.get("isError") is True
+        assert "light_chain" in f"{result.get('summary', '')} {result.get('detail', '')}"
+
+    def test_run_rejects_tcr_without_beta_chain(self, immunebuilder_module):
+        result = immunebuilder_module.run(
+            mode="tcr",
+            alpha_chain=VALID_ALPHA_CHAIN,
+        )
+
+        assert isinstance(result, dict)
+        assert result.get("error")
+        assert result.get("isError") is True
+        assert "beta_chain" in f"{result.get('summary', '')} {result.get('detail', '')}"
+
+    def test_run_rejects_mixed_chain_families(self, immunebuilder_module):
+        result = immunebuilder_module.run(
+            mode="antibody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+            light_chain=VALID_LIGHT_CHAIN,
+            alpha_chain=VALID_ALPHA_CHAIN,
+            beta_chain=VALID_BETA_CHAIN,
+        )
+
+        assert isinstance(result, dict)
+        assert result.get("error")
+        assert result.get("isError") is True
+        detail_blob = f"{result.get('summary', '')} {result.get('detail', '')}".lower()
+        assert "alpha_chain" in detail_blob or "beta_chain" in detail_blob or "tcr" in detail_blob
+
+    def test_run_predicts_antibody_with_mocked_immunebuilder(
+        self,
+        immunebuilder_module,
+        monkeypatch,
+    ):
+        class FakePrediction:
+            def save(self, path: str):
+                Path(path).write_text(
+                    "HEADER MOCK\n"
+                    "ATOM      1  CA  ALA H   1       0.0   0.0   0.0  1.00 70.00           C\n"
+                    "END\n"
+                )
+
+        class FakeABodyBuilder2:
+            last_sequences = None
+
+            def predict(self, sequences):
+                type(self).last_sequences = sequences
+                return FakePrediction()
+
+        fake_module = types.SimpleNamespace(
+            ABodyBuilder2=FakeABodyBuilder2,
+            NanoBodyBuilder2=type("FakeNanoBodyBuilder2", (), {}),
+            TCRBuilder2=type("FakeTCRBuilder2", (), {}),
+        )
+        monkeypatch.setitem(sys.modules, "ImmuneBuilder", fake_module)
+
+        result = immunebuilder_module.run(
+            mode="antibody",
+            heavy_chain=VALID_HEAVY_CHAIN,
+            light_chain=VALID_LIGHT_CHAIN,
+        )
+
+        assert result["mode"] == "antibody"
+        assert result["chain_labels"] == ["H", "L"]
+        assert result["num_chains"] == 2
+        assert "HEADER MOCK" in result["pdb_content"]
+        assert result["metrics"]["predictor"] == "FakeABodyBuilder2"
+        assert FakeABodyBuilder2.last_sequences == {"H": VALID_HEAVY_CHAIN, "L": VALID_LIGHT_CHAIN}

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -1,16 +1,10 @@
 """Tests for local GPU runner — mock Docker subprocess calls."""
 
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 import json
 import pytest
-
-
-@pytest.fixture(autouse=True)
-def mock_manifest_for_runner():
-    """Mock manifest lookups so weight check doesn't block tests."""
-    with patch("ct.cloud.manifest.get_tool_config", return_value=None):
-        yield
 
 
 @dataclass
@@ -31,6 +25,21 @@ class FakeTool:
 
 class TestLocalRunner:
     """Test Docker-based local GPU execution."""
+
+    def test_tool_docker_build_context_stages_shared_schema(self):
+        from ct.cloud.local_runner import tool_docker_build_context
+
+        repo_root = Path(__file__).resolve().parents[1]
+        tool_dir = repo_root / "src/ct/tools/immunebuilder"
+
+        with tool_docker_build_context(tool_dir) as docker_context:
+            assert (docker_context / "implementation.py").exists()
+            assert (docker_context / "tool_entrypoint.py").exists()
+
+            staged_schema = docker_context / "ct/tools/_schema_contract.py"
+            shared_schema = repo_root / "src/ct/tools/_schema_contract.py"
+            assert staged_schema.exists()
+            assert staged_schema.read_text(encoding="utf-8") == shared_schema.read_text(encoding="utf-8")
 
     def test_run_with_output(self, tmp_path):
         from ct.cloud.local_runner import LocalRunner


### PR DESCRIPTION
## Summary

- **New tool: `structure.immunebuilder`** — GPU container tool for predicting antibody, nanobody, and TCR structures from named chain sequences (`heavy_chain`, `light_chain`, `alpha_chain`, `beta_chain`). Strict Pydantic validation with mode-aware chain enforcement; rejects generic `sequence`/`chains`/`fasta` inputs.
- **`tool_docker_build_context()`** in `local_runner.py` — context manager that stages a clean per-tool Docker build directory, copying `tool_entrypoint.py` and `_schema_contract.py` into the expected layout without mutating the source tree. Used by both `LocalRunner.ensure_image()` and `ct tool pull`.
- **`_resolve_cache_dir()`** — graceful fallback when a model cache directory can't be created (read-only FS, permission errors). Tries `CT_LOCAL_CACHE_ROOT`, workspace `.cache`, and `/tmp` before skipping the mount.
- **`TraceLogger`** extracted to `src/ct/agent/trace.py`. Text-only responses now count as activity, so queries answered without tool calls no longer trigger false trace-integrity warnings. Diagnostics also flag interrupted tool calls (`step_start` without matching result) and `to_text()` preserves direct-answer content in exported bundles.
- **`_tool_pull_test_input()`** — centralises warmup payloads per tool so `structure.immunebuilder` gets a valid named-chain nanobody payload instead of the generic `{"sequence": "MKWV"}` fallback.
- **`_pytest_cmd()`** — runs pytest via `sys.executable -m pytest` for consistent venv resolution in `release-check`.

## Test plan

- [ ] `pytest tests/test_immunebuilder.py` — 8 contract tests (schema, validation, mock prediction)
- [ ] `pytest tests/test_local_runner.py` — includes `test_tool_docker_build_context_stages_shared_schema`
- [ ] `pytest tests/test_cli.py` — warmup payload + text-only trace tests
- [ ] `pytest tests/test_gpu_registry.py` — `test_immunebuilder_registers_gpu_metadata`
- [ ] `ct tool pull structure.immunebuilder --force` on a Docker + NVIDIA GPU host to validate the full build + warmup flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)